### PR TITLE
fix(desktop): hide dock/taskbar on close and add Cmd/Ctrl+W

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -217,9 +217,12 @@ void main(List<String> args) async {
   // Mobile: fixed tier avoids mid-session downgrades on the tab bar; revisit
   // if old devices need the adaptive benchmark.
   final isDesktop = Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+  final desktopAppRoot = Platform.isWindows
+      ? DesktopWindowCloseShortcuts(child: appRoot)
+      : appRoot;
   runApp(
     isDesktop
-        ? appRoot
+        ? desktopAppRoot
         : LiquidGlassWidgets.wrap(adaptiveQuality: false, child: appRoot),
   );
 

--- a/app/lib/services/desktop_tray_lifecycle.dart
+++ b/app/lib/services/desktop_tray_lifecycle.dart
@@ -13,6 +13,11 @@ const _kDesktopLifecycleChannel = MethodChannel(
 
 bool get desktopTraySupported => Platform.isWindows || Platform.isMacOS;
 
+Future<void> _setSkipTaskbar(bool skip) async {
+  if (!desktopTraySupported) return;
+  await windowManager.setSkipTaskbar(skip);
+}
+
 final _DesktopWindowListener _windowListener = _DesktopWindowListener();
 final _TrayShowListener _trayShowListener = _TrayShowListener();
 bool _trayInitialized = false;
@@ -21,9 +26,7 @@ class _DesktopWindowListener with WindowListener {
   @override
   void onWindowClose() {
     Future<void>(() async {
-      if (Platform.isWindows) {
-        await windowManager.setSkipTaskbar(true);
-      }
+      await _setSkipTaskbar(true);
       await windowManager.hide();
     });
   }
@@ -64,9 +67,7 @@ class _TrayShowListener with TrayListener {
 
 Future<void> bringMainWindowToFront() async {
   if (!desktopTraySupported) return;
-  if (Platform.isWindows) {
-    await windowManager.setSkipTaskbar(false);
-  }
+  await _setSkipTaskbar(false);
   if (await windowManager.isMinimized()) {
     await windowManager.restore();
   }
@@ -98,7 +99,7 @@ Future<void> initDesktopWindowBeforeRunApp({bool startHidden = false}) async {
           : const Size(1280, 720),
       center: savedBounds == null,
       title: 'ShrimpSend',
-      skipTaskbar: startHidden && Platform.isWindows,
+      skipTaskbar: startHidden,
     ),
     () async {
       if (savedBounds != null) {
@@ -107,9 +108,7 @@ Future<void> initDesktopWindowBeforeRunApp({bool startHidden = false}) async {
         );
       }
       if (startHidden) {
-        if (Platform.isWindows) {
-          await windowManager.setSkipTaskbar(true);
-        }
+        await _setSkipTaskbar(true);
         await windowManager.hide();
         return;
       }
@@ -158,4 +157,37 @@ Future<void> initDesktopTrayAfterFirstFrame() async {
       ],
     ),
   );
+}
+
+class _CloseWindowIntent extends Intent {
+  const _CloseWindowIntent();
+}
+
+/// Windows: Ctrl+W closes the window (same as clicking X — hide to tray).
+class DesktopWindowCloseShortcuts extends StatelessWidget {
+  const DesktopWindowCloseShortcuts({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!Platform.isWindows) return child;
+    return Shortcuts(
+      shortcuts: const {
+        SingleActivator(LogicalKeyboardKey.keyW, control: true):
+            _CloseWindowIntent(),
+      },
+      child: Actions(
+        actions: {
+          _CloseWindowIntent: CallbackAction<_CloseWindowIntent>(
+            onInvoke: (_) {
+              windowManager.close();
+              return null;
+            },
+          ),
+        },
+        child: child,
+      ),
+    );
+  }
 }

--- a/app/macos/Runner/Base.lproj/MainMenu.xib
+++ b/app/macos/Runner/Base.lproj/MainMenu.xib
@@ -302,6 +302,11 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
                         <items>
+                            <menuItem title="Close Window" keyEquivalent="w" id="Dvo-aI-Pon">
+                                <connections>
+                                    <action selector="performClose:" target="-1" id="Ol3-gK-z6a"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
                                 <connections>
                                     <action selector="performMiniaturize:" target="-1" id="VwT-WD-YPe"/>


### PR DESCRIPTION
Hide the Mac Dock when closing to tray via activation policy, restore it when showing the window again, and wire Cmd+W (macOS) and Ctrl+W (Windows) to the same close-to-tray flow as the X button.