### PR TITLE
Fix export status sync and prioritize save folder tab in file manager.

### DIFF
--- a/app/lib/screens/file_manager_screen.dart
+++ b/app/lib/screens/file_manager_screen.dart
@@ -88,7 +88,7 @@ class _FileManagerScreenState extends State<FileManagerScreen>
 
   bool get _isSearching => _searchQuery.isNotEmpty;
 
-  bool get _isSaveFolderTab => _tabController.index == 1;
+  bool get _isSaveFolderTab => _tabController.index == 0;
 
   List<ReceivedFileInfo> get _activeFiles =>
       _isSaveFolderTab ? _filteredSaveFolderFiles : _files;
@@ -109,6 +109,7 @@ class _FileManagerScreenState extends State<FileManagerScreen>
     _scrollController.addListener(_onScroll);
     _loadReceiveDirPath();
     unawaited(_loadSaveFolderDisplayInfo());
+    unawaited(_loadSaveFolderFiles());
     unawaited(_loadSortPreference().then((_) => _loadFiles()));
     ReceivedFileDao.addChangedListener(_onIndexChanged);
     FileStore.addReceiveDirChangedListener(_onReceiveDirChanged);
@@ -133,6 +134,7 @@ class _FileManagerScreenState extends State<FileManagerScreen>
     _indexChangeDebounce = Timer(const Duration(milliseconds: 250), () {
       if (!mounted) return;
       _silentRefreshFiles();
+      unawaited(_silentRefreshSaveFolder());
     });
   }
 
@@ -178,7 +180,7 @@ class _FileManagerScreenState extends State<FileManagerScreen>
 
   /// Reload listing without clearing the list or showing the full-screen loading state.
   Future<void> _silentRefreshFiles() async {
-    if (!mounted || _loading) return;
+    if (!mounted) return;
 
     try {
       await _loadReceiveDirPath(invalidateDirCache: true);
@@ -387,7 +389,7 @@ class _FileManagerScreenState extends State<FileManagerScreen>
   }
 
   Future<void> _silentRefreshSaveFolder() async {
-    if (!mounted || _saveFolderLoading) return;
+    if (!mounted) return;
     await _loadSaveFolderFiles(showBlockingLoading: false);
   }
 
@@ -1230,6 +1232,29 @@ class _FileManagerScreenState extends State<FileManagerScreen>
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              Text(l10n.fmSaveFolderHintTitle, style: sectionTitleStyle),
+              const SizedBox(height: AppSpacing.xxs),
+              Text(
+                _isDesktop
+                    ? l10n.fmSaveFolderHintBodyDesktop
+                    : l10n.fmSaveFolderHintBody,
+                style: bodyStyle,
+              ),
+              if (saveFolderInfo.path != null &&
+                  saveFolderInfo.path!.isNotEmpty) ...[
+                const SizedBox(height: AppSpacing.sm),
+                Text(l10n.fmSaveFolderPathLabel, style: pathLabelStyle),
+                const SizedBox(height: AppSpacing.xxs),
+                SelectableText(
+                  saveFolderInfo.label != null &&
+                          saveFolderInfo.label!.isNotEmpty &&
+                          saveFolderInfo.label != saveFolderInfo.path
+                      ? '${saveFolderInfo.label!}\n${saveFolderInfo.path!}'
+                      : saveFolderInfo.path!,
+                  style: pathStyle,
+                ),
+              ],
+              const SizedBox(height: AppSpacing.md),
               Row(
                 children: [
                   Expanded(
@@ -1263,29 +1288,6 @@ class _FileManagerScreenState extends State<FileManagerScreen>
                 Text(l10n.fmCachePathLabel, style: pathLabelStyle),
                 const SizedBox(height: AppSpacing.xxs),
                 SelectableText(_receiveDirPath!, style: pathStyle),
-              ],
-              const SizedBox(height: AppSpacing.md),
-              Text(l10n.fmSaveFolderHintTitle, style: sectionTitleStyle),
-              const SizedBox(height: AppSpacing.xxs),
-              Text(
-                _isDesktop
-                    ? l10n.fmSaveFolderHintBodyDesktop
-                    : l10n.fmSaveFolderHintBody,
-                style: bodyStyle,
-              ),
-              if (saveFolderInfo.path != null &&
-                  saveFolderInfo.path!.isNotEmpty) ...[
-                const SizedBox(height: AppSpacing.sm),
-                Text(l10n.fmSaveFolderPathLabel, style: pathLabelStyle),
-                const SizedBox(height: AppSpacing.xxs),
-                SelectableText(
-                  saveFolderInfo.label != null &&
-                          saveFolderInfo.label!.isNotEmpty &&
-                          saveFolderInfo.label != saveFolderInfo.path
-                      ? '${saveFolderInfo.label!}\n${saveFolderInfo.path!}'
-                      : saveFolderInfo.path!,
-                  style: pathStyle,
-                ),
               ],
             ],
           ),
@@ -1428,8 +1430,8 @@ class _FileManagerScreenState extends State<FileManagerScreen>
                 unselectedLabelColor: colors.textSecondary,
                 dividerColor: colors.border,
                 tabs: [
-                  Tab(text: l10n.fmTabCache),
                   Tab(text: _saveFolderTabLabel(l10n)),
+                  Tab(text: l10n.fmTabCache),
                 ],
               ),
         leading: _isSelectionMode
@@ -1545,8 +1547,8 @@ class _FileManagerScreenState extends State<FileManagerScreen>
             child: TabBarView(
               controller: _tabController,
               children: [
-                _buildCacheTabBody(context),
                 _buildSaveFolderTabBody(context),
+                _buildCacheTabBody(context),
               ],
             ),
           ),

--- a/app/lib/services/received_file_dao.dart
+++ b/app/lib/services/received_file_dao.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:path/path.dart' as p;
 import 'package:sqflite/sqflite.dart';
 
@@ -143,7 +144,11 @@ class ReceivedFileDao {
   ReceivedFileDao._();
   static final instance = ReceivedFileDao._();
 
-  Database get _db => AppDatabase.instance.db;
+  /// In-memory DB for unit tests; when null, uses [AppDatabase.instance].
+  @visibleForTesting
+  static Database? testDatabase;
+
+  Database get _db => testDatabase ?? AppDatabase.instance.db;
 
   static final List<void Function()> _changedListeners = [];
 
@@ -509,21 +514,47 @@ class ReceivedFileDao {
       if (knownPaths.contains(first.path)) continue;
       final existing = await _db.query(
         _table,
-        columns: ['message_id', 'abs_path'],
+        columns: [
+          'message_id',
+          'abs_path',
+          'cache_path',
+          'export_status',
+          'visible_path',
+        ],
         where: 'message_id = ?',
         whereArgs: [dirName],
         limit: 1,
       );
       if (existing.isNotEmpty) {
-        final knownPath = existing.first['abs_path'] as String? ?? '';
-        if (knownPath != first.path) {
-          await upsert(
-            messageId: dirName,
-            absPath: first.path,
-            cachePath: first.path,
-            protocol: _inferProtocolFromMessageId(dirName),
-            exportStatus: ExportStatus.pending,
+        final row = existing.first;
+        final knownPath = row['abs_path'] as String? ?? '';
+        final currentCachePath = row['cache_path'] as String?;
+        if (knownPath != first.path || currentCachePath != first.path) {
+          final exportStatus = ReceivedFileRecord._parseExportStatus(
+            row['export_status'] as String?,
           );
+          if (exportStatus == ExportStatus.done ||
+              exportStatus == ExportStatus.exporting) {
+            final visiblePath = row['visible_path'] as String?;
+            await updateExportState(
+              messageId: dirName,
+              exportStatus: exportStatus,
+              cachePath: first.path,
+              absPath: FileStore.resolveReadablePath(
+                cachePath: first.path,
+                visiblePath: visiblePath,
+                absPath: knownPath.isNotEmpty ? knownPath : first.path,
+              ),
+            );
+          } else {
+            await upsert(
+              messageId: dirName,
+              absPath: first.path,
+              cachePath: first.path,
+              protocol: _inferProtocolFromMessageId(dirName),
+              exportStatus: ExportStatus.pending,
+            );
+          }
           changed++;
         }
         continue;

--- a/app/test/received_file_dao_reconcile_test.dart
+++ b/app/test/received_file_dao_reconcile_test.dart
@@ -1,0 +1,137 @@
+import 'dart:io';
+
+import 'package:app/services/received_file_dao.dart';
+import 'package:app/services/visible_export_target.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+const _createReceivedFiles = '''
+CREATE TABLE received_files (
+  message_id     TEXT PRIMARY KEY,
+  user_id        TEXT,
+  thread_key     TEXT,
+  dir_name       TEXT NOT NULL,
+  file_name      TEXT NOT NULL,
+  abs_path       TEXT NOT NULL,
+  protocol       TEXT,
+  category       TEXT,
+  size           INTEGER NOT NULL DEFAULT 0,
+  mtime          INTEGER NOT NULL DEFAULT 0,
+  created_at     INTEGER NOT NULL DEFAULT 0,
+  s3_key         TEXT,
+  from_device_id TEXT,
+  deleted        INTEGER NOT NULL DEFAULT 0,
+  cache_path     TEXT,
+  visible_path   TEXT,
+  export_status  TEXT,
+  export_target  TEXT,
+  gallery_saved  INTEGER NOT NULL DEFAULT 0,
+  export_error   TEXT,
+  exported_at    INTEGER
+);
+''';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  group('ReceivedFileDao.reconcileWithRoot', () {
+    late Database db;
+    late Directory cacheRoot;
+    late Directory visibleRoot;
+
+    setUp(() async {
+      db = await openDatabase(
+        inMemoryDatabasePath,
+        version: 1,
+        onCreate: (database, version) async {
+          await database.execute(_createReceivedFiles);
+        },
+      );
+      ReceivedFileDao.testDatabase = db;
+
+      cacheRoot = await Directory.systemTemp.createTemp('reconcile_cache_');
+      visibleRoot = await Directory.systemTemp.createTemp('reconcile_visible_');
+    });
+
+    tearDown(() async {
+      ReceivedFileDao.testDatabase = null;
+      await db.close();
+      if (await cacheRoot.exists()) {
+        await cacheRoot.delete(recursive: true);
+      }
+      if (await visibleRoot.exists()) {
+        await visibleRoot.delete(recursive: true);
+      }
+    });
+
+    test('preserves done export_status when cache file path differs from abs_path',
+        () async {
+      const messageId = 'lan_recv_reconcile_test';
+      final cacheDir = Directory(p.join(cacheRoot.path, messageId));
+      await cacheDir.create(recursive: true);
+      final cacheFile = File(p.join(cacheDir.path, 'photo.jpg'));
+      await cacheFile.writeAsBytes([1, 2, 3, 4]);
+
+      final visibleFile = File(p.join(visibleRoot.path, 'photo.jpg'));
+      await visibleFile.writeAsBytes([1, 2, 3, 4]);
+
+      await ReceivedFileDao.instance.upsert(
+        messageId: messageId,
+        absPath: cacheFile.path,
+        cachePath: cacheFile.path,
+        protocol: 'lan',
+        exportStatus: ExportStatus.pending,
+      );
+      await ReceivedFileDao.instance.updateExportState(
+        messageId: messageId,
+        exportStatus: ExportStatus.done,
+        visiblePath: visibleFile.path,
+        absPath: visibleFile.path,
+        clearCachePath: true,
+      );
+
+      await ReceivedFileDao.instance.reconcileWithRoot(cacheRoot.path);
+
+      final record =
+          await ReceivedFileDao.instance.getByMessageId(messageId);
+      expect(record, isNotNull);
+      expect(record!.exportStatus, ExportStatus.done);
+      expect(record.visiblePath, visibleFile.path);
+      expect(record.cachePath, cacheFile.path);
+      expect(record.absPath, cacheFile.path);
+    });
+
+    test('resets pending export_status when cache path changes for unexported row',
+        () async {
+      const messageId = 's3_recv_reconcile_pending';
+      final cacheDir = Directory(p.join(cacheRoot.path, messageId));
+      await cacheDir.create(recursive: true);
+      final cacheFile = File(p.join(cacheDir.path, 'doc.pdf'));
+      await cacheFile.writeAsBytes([5, 6, 7]);
+
+      await ReceivedFileDao.instance.upsert(
+        messageId: messageId,
+        absPath: p.join(cacheRoot.path, 'stale', 'doc.pdf'),
+        cachePath: p.join(cacheRoot.path, 'stale', 'doc.pdf'),
+        protocol: 's3',
+        exportStatus: ExportStatus.pending,
+      );
+
+      await ReceivedFileDao.instance.reconcileWithRoot(cacheRoot.path);
+
+      final record =
+          await ReceivedFileDao.instance.getByMessageId(messageId);
+      expect(record, isNotNull);
+      expect(record!.exportStatus, ExportStatus.pending);
+      expect(record.cachePath, cacheFile.path);
+      expect(record.absPath, cacheFile.path);
+    });
+  });
+}


### PR DESCRIPTION
Prevent reconcileWithRoot from resetting exported files to pending, refresh both tabs after receives, and default file manager to the user-visible save folder.