### PR TITLE
fix(web): use NEXT_PUBLIC_ADMIN_EMAILS for admin UI gate

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -32,5 +32,5 @@ NEXT_PUBLIC_OPENPANEL_INTL_CLIENT_ID=
 NEXT_PUBLIC_OPENPANEL_INTL_CLIENT_SECRET=
 NEXT_PUBLIC_OPENPANEL_INTL_API_URL=https://openpanel.example.com/api
 
-# 管理员邮箱（逗号分隔，与后端 APP_ADMIN_EMAILS 一致）
-ADMIN_EMAILS=admin@example.com
+# 管理员邮箱（逗号分隔，须与后端 APP_ADMIN_EMAILS 一致；NEXT_PUBLIC_ 前缀才能打进前端 bundle，修改后需重新 build）
+NEXT_PUBLIC_ADMIN_EMAILS=admin@example.com

--- a/web/src/lib/adminEmails.ts
+++ b/web/src/lib/adminEmails.ts
@@ -1,9 +1,10 @@
-/** 与后端 {@code app.admin.emails} 保持一致（用于前端门禁展示）；权限以后端为准 */
+/**
+ * 与后端 {@code app.admin.emails} 保持一致，仅用于 UI 展示门禁。
+ * 须配置 {@code NEXT_PUBLIC_ADMIN_EMAILS}（客户端 bundle 无法读取无 NEXT_PUBLIC_ 前缀的变量）。
+ * 真实权限以后端 {@code AdminAuthService} 为准。
+ */
 function parseAdminEmails(): Set<string> {
-  const raw =
-    process.env.ADMIN_EMAILS ??
-    process.env.NEXT_PUBLIC_ADMIN_EMAILS ??
-    '';
+  const raw = process.env.NEXT_PUBLIC_ADMIN_EMAILS ?? '';
   return new Set(
     raw
       .split(',')


### PR DESCRIPTION
Client components cannot read ADMIN_EMAILS; the empty whitelist hid the admin entry in settings.