### PR TITLE
Point landing page client download to GitHub Releases.

### DIFF
--- a/web/src/components/landing/LandingPage.tsx
+++ b/web/src/components/landing/LandingPage.tsx
@@ -3,7 +3,8 @@
 import Link from 'next/link';
 import { useAuth } from '@/contexts/AuthContext';
 import { useI18n } from '@/contexts/I18nContext';
-import { getClientReleaseDownloadUrl, isClientDownloadOverseas } from '@/lib/clientReleaseDownload';
+import { isClientDownloadOverseas } from '@/lib/clientReleaseDownload';
+import { OPEN_SOURCE_RELEASES_URL } from '@/lib/openSource';
 import { SiteFooter } from '@/components/landing/SiteFooter';
 import { SiteNav } from '@/components/landing/SiteNav';
 import { buttonVariants } from '@/components/ui/button';
@@ -504,7 +505,7 @@ export function LandingPage({ localePath, siteOrigin }: { localePath: LocalePath
   const { t } = useI18n();
   const { accessToken } = useAuth();
   const pricingRegion = getPricingRegion(siteOrigin);
-  const releaseHref = getClientReleaseDownloadUrl({ siteOrigin });
+  const releaseHref = OPEN_SOURCE_RELEASES_URL;
   const purchaseHref = accessToken ? '/settings/membership' : '/login?next=%2Fsettings%2Fmembership';
   const webTrialHref = accessToken ? '/chat' : '/login?next=%2Fchat';
   const visiblePricingPlans = pricingPlans.filter((plan) => plan.region === pricingRegion);

--- a/web/src/lib/openSource.ts
+++ b/web/src/lib/openSource.ts
@@ -1,2 +1,5 @@
 /** Public source repository (AGPL §13 / community transparency). */
 export const OPEN_SOURCE_REPO_URL = 'https://github.com/shrimpsend/shrimpsend';
+
+/** Published client builds on GitHub Releases. */
+export const OPEN_SOURCE_RELEASES_URL = 'https://github.com/shrimpsend/shrimpsend/releases';


### PR DESCRIPTION
Replace region-specific cloud drive links with the public releases page on the homepage hero download button.