### PR TITLE
Update regional client download links for mainland and overseas.

### DIFF
--- a/web/src/components/landing/LandingPage.tsx
+++ b/web/src/components/landing/LandingPage.tsx
@@ -3,8 +3,7 @@
 import Link from 'next/link';
 import { useAuth } from '@/contexts/AuthContext';
 import { useI18n } from '@/contexts/I18nContext';
-import { isClientDownloadOverseas } from '@/lib/clientReleaseDownload';
-import { OPEN_SOURCE_RELEASES_URL } from '@/lib/openSource';
+import { getClientReleaseDownloadUrl, isClientDownloadOverseas } from '@/lib/clientReleaseDownload';
 import { SiteFooter } from '@/components/landing/SiteFooter';
 import { SiteNav } from '@/components/landing/SiteNav';
 import { buttonVariants } from '@/components/ui/button';
@@ -505,7 +504,7 @@ export function LandingPage({ localePath, siteOrigin }: { localePath: LocalePath
   const { t } = useI18n();
   const { accessToken } = useAuth();
   const pricingRegion = getPricingRegion(siteOrigin);
-  const releaseHref = OPEN_SOURCE_RELEASES_URL;
+  const releaseHref = getClientReleaseDownloadUrl({ siteOrigin });
   const purchaseHref = accessToken ? '/settings/membership' : '/login?next=%2Fsettings%2Fmembership';
   const webTrialHref = accessToken ? '/chat' : '/login?next=%2Fchat';
   const visiblePricingPlans = pricingPlans.filter((plan) => plan.region === pricingRegion);

--- a/web/src/lib/clientReleaseDownload.ts
+++ b/web/src/lib/clientReleaseDownload.ts
@@ -1,12 +1,12 @@
 import { getApiUrl } from '@/lib/config';
+import { OPEN_SOURCE_RELEASES_URL } from '@/lib/openSource';
 
 /** 国内分发：123 云盘分享页 */
 export const CLIENT_RELEASE_URL_MAINLAND =
-  'https://1816849228.share.123pan.cn/123pan/cXByVv-Z76m';
+  'https://1816849228.share.123pan.cn/123pan/cXByVv-YjG1';
 
-/** 出海分发：Google Drive 分享文件夹 */
-export const CLIENT_RELEASE_URL_OVERSEAS =
-  'https://drive.google.com/drive/folders/1_BL255lRlZkXGcO447htvtpHItpzJGaA?usp=drive_link';
+/** 出海分发：GitHub Releases */
+export const CLIENT_RELEASE_URL_OVERSEAS = OPEN_SOURCE_RELEASES_URL;
 
 export type WebDeploymentRegionHint = {
   /** 请求 Host（SSR 从 headers 传入） */

--- a/web/src/messages/en.json
+++ b/web/src/messages/en.json
@@ -123,9 +123,9 @@
     "downloadRegionMainland": "Mainland downloads",
     "downloadRegionOverseas": "International downloads",
     "downloadPanelTitle": "Install ShrimpSend on your other devices",
-    "downloadPanelSubtitle": "Install the desktop or mobile app before signing in. Open 123pan or Google Drive for your region and pick the installer for your platform.",
+    "downloadPanelSubtitle": "Install the desktop or mobile app before signing in. Open 123pan or GitHub Releases for your region and pick the installer for your platform.",
     "downloadReleasesGitee": "123pan Download",
-    "downloadReleasesGithub": "Google Drive Download",
+    "downloadReleasesGithub": "GitHub Releases Download",
     "downloadReleasesCta": "Opens in a new tab — choose your platform installer",
     "downloadPlatformsHint": "macOS, Windows, Android, iOS, and more"
   },
@@ -260,7 +260,7 @@
     "faqS3Q": "When should I configure S3?",
     "faqS3A": "Use S3-compatible storage when you often send large files across cities or networks, or want file staging in your own object storage.",
     "downloadsTitle": "Download for every platform",
-    "downloadsHint": "Open 123pan or Google Drive for your region to download installers for each platform."
+    "downloadsHint": "Open 123pan or GitHub Releases for your region to download installers for each platform."
   },
   "settings": {
     "title": "Settings",

--- a/web/src/messages/zh.json
+++ b/web/src/messages/zh.json
@@ -123,9 +123,9 @@
     "downloadRegionMainland": "中国大陆下载",
     "downloadRegionOverseas": "国际版下载",
     "downloadPanelTitle": "在其他设备上安装虾传",
-    "downloadPanelSubtitle": "登录网页版前，也可先安装桌面端或移动端。请根据当前服务区域前往 123 云盘或 Google Drive，按平台选择安装包下载。",
+    "downloadPanelSubtitle": "登录网页版前，也可先安装桌面端或移动端。请根据当前服务区域前往 123 云盘或 GitHub Releases，按平台选择安装包下载。",
     "downloadReleasesGitee": "123 云盘下载",
-    "downloadReleasesGithub": "Google Drive 下载",
+    "downloadReleasesGithub": "GitHub Releases 下载",
     "downloadReleasesCta": "在新标签页打开，选择对应平台安装包",
     "downloadPlatformsHint": "支持 macOS、Windows、Android、iOS 等平台"
   },
@@ -260,7 +260,7 @@
     "faqS3Q": "什么时候需要配置 S3？",
     "faqS3A": "当你经常跨城市、跨网络传大文件，或希望文件暂存到自己的对象存储时，S3 兼容存储会更稳定。",
     "downloadsTitle": "全平台客户端",
-    "downloadsHint": "根据当前服务区域前往 123 云盘或 Google Drive 下载各平台安装包。"
+    "downloadsHint": "根据当前服务区域前往 123 云盘或 GitHub Releases 下载各平台安装包。"
   },
   "settings": {
     "title": "设置",


### PR DESCRIPTION
Point mainland users to the new 123pan share page and restore overseas downloads to GitHub Releases.