### PR TITLE
Fix false export-failure toast after LAN/WebRTC receive re-key.

### DIFF
--- a/app/lib/screens/chat_screen.dart
+++ b/app/lib/screens/chat_screen.dart
@@ -4007,24 +4007,13 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
                 );
               }
               try {
-                final oldRow = await ReceivedFileDao.instance.getByMessageId(
-                  upgradeFromMsgId,
+                await ReceivedFileIndexPipeline.instance.rekeyAfterBubbleUpgrade(
+                  oldMessageId: upgradeFromMsgId,
+                  newMessageId: message.id,
+                  userId: userId,
+                  threadKey: rowTk,
+                  fromDeviceId: msg.fromDeviceId,
                 );
-                if (oldRow != null) {
-                  await ReceivedFileDao.instance.upsert(
-                    messageId: message.id,
-                    absPath: oldRow.absPath,
-                    userId: oldRow.userId ?? userId,
-                    threadKey: oldRow.threadKey ?? rowTk,
-                    protocol: oldRow.protocol,
-                    s3Key: oldRow.s3Key,
-                    fromDeviceId: oldRow.fromDeviceId ?? msg.fromDeviceId,
-                    size: oldRow.size,
-                  );
-                  await ReceivedFileDao.instance.removeByMessageId(
-                    upgradeFromMsgId,
-                  );
-                }
               } catch (e) {
                 logChat.warning(
                   'chat_screen failed to re-key received_files from '

--- a/app/lib/services/file_export_pipeline.dart
+++ b/app/lib/services/file_export_pipeline.dart
@@ -318,16 +318,9 @@ class FileExportPipeline {
       absPath: record.absPath,
     );
 
-    if (await getDeleteCacheAfterSave()) {
-      cachePath = '';
+    final shouldClearCache = await getDeleteCacheAfterSave();
+    if (shouldClearCache) {
       absPath = exportResult.location ?? absPath;
-      final removed = await FileStore.deleteByMessageId(messageId);
-      if (!removed) {
-        _log.warning(
-          'delete cache after export deferred for $messageId (file may be in use)',
-        );
-        unawaited(FileStore.deleteCacheEntryWhenReady(messageId));
-      }
     }
 
     await ReceivedFileDao.instance.updateExportState(
@@ -337,9 +330,19 @@ class FileExportPipeline {
       exportTarget: exportResult.targetKind,
       gallerySaved: gallerySaved,
       absPath: absPath,
-      cachePath: cachePath.isEmpty ? null : cachePath,
-      clearCachePath: cachePath.isEmpty,
+      cachePath: shouldClearCache ? null : cachePath,
+      clearCachePath: shouldClearCache,
     );
+
+    if (shouldClearCache) {
+      final removed = await FileStore.deleteByMessageId(messageId);
+      if (!removed) {
+        _log.warning(
+          'delete cache after export deferred for $messageId (file may be in use)',
+        );
+        unawaited(FileStore.deleteCacheEntryWhenReady(messageId));
+      }
+    }
 
     if (exportResult.location != null &&
         exportResult.location!.isNotEmpty &&
@@ -424,6 +427,13 @@ class FileExportPipeline {
 
   Future<void> _cleanupCacheAfterExportIfNeeded(ReceivedFileRecord record) async {
     if (!await getDeleteCacheAfterSave()) return;
+    if (record.exportStatus == ExportStatus.legacy) return;
+    if (record.exportStatus != ExportStatus.done) return;
+
+    final hasVisibleCopy = record.gallerySaved ||
+        (record.visiblePath != null && record.visiblePath!.isNotEmpty);
+    if (!hasVisibleCopy) return;
+
     final cachePath = record.cachePath;
     if (cachePath == null || cachePath.isEmpty) return;
 

--- a/app/lib/services/received_file_dao.dart
+++ b/app/lib/services/received_file_dao.dart
@@ -435,6 +435,55 @@ class ReceivedFileDao {
     _notifyChanged();
   }
 
+  /// Re-keys a row to the server-side message id while preserving export state.
+  ///
+  /// Returns `true` when the old row existed and was updated.
+  Future<bool> rekeyMessageId({
+    required String oldMessageId,
+    required String newMessageId,
+    String? userId,
+    String? threadKey,
+    String? fromDeviceId,
+  }) async {
+    if (oldMessageId.isEmpty ||
+        newMessageId.isEmpty ||
+        oldMessageId == newMessageId) {
+      return false;
+    }
+
+    final oldRows = await _db.query(
+      _table,
+      where: 'message_id = ?',
+      whereArgs: [oldMessageId],
+      limit: 1,
+    );
+    if (oldRows.isEmpty) return false;
+
+    await _db.delete(
+      _table,
+      where: 'message_id = ?',
+      whereArgs: [newMessageId],
+    );
+
+    final data = <String, Object?>{
+      'message_id': newMessageId,
+    };
+    if (userId != null) data['user_id'] = userId;
+    if (threadKey != null) data['thread_key'] = threadKey;
+    if (fromDeviceId != null) data['from_device_id'] = fromDeviceId;
+
+    final updated = await _db.update(
+      _table,
+      data,
+      where: 'message_id = ?',
+      whereArgs: [oldMessageId],
+    );
+    if (updated > 0) {
+      _notifyChanged();
+    }
+    return updated > 0;
+  }
+
   Future<void> reparentRoot(String oldPrefix, String newPrefix) async {
     if (oldPrefix == newPrefix) return;
     await _db.rawUpdate(

--- a/app/lib/services/received_file_index_pipeline.dart
+++ b/app/lib/services/received_file_index_pipeline.dart
@@ -1,57 +1,80 @@
-import 'dart:async';
-import 'dart:io' show Platform;
-
-import 'package:flutter/foundation.dart' show kIsWeb;
-
-import '../logger.dart';
-import 'file_export_pipeline.dart';
-import 'received_file_dao.dart';
-
-final _log = logChat;
-
-/// Brief pause after index write so cache files finish flushing before export.
-Duration _settleAfterUpsert() {
-  if (kIsWeb) return Duration.zero;
-  if (Platform.isWindows || Platform.isMacOS || Platform.isLinux) {
-    return const Duration(milliseconds: 50);
-  }
-  return const Duration(milliseconds: 50);
-}
-
-/// Serializes [ReceivedFileDao.upsert] + inline [FileExportPipeline.exportNow]
-/// so each received file is exported before the next finalize runs.
-class ReceivedFileIndexPipeline {
-  ReceivedFileIndexPipeline._();
-  static final instance = ReceivedFileIndexPipeline._();
-
-  Future<void>? _tail;
-
-  /// Runs [upsert] then immediately exports to visible storage.
-  /// Returns `true` when export reaches [ExportStatus.done].
-  /// Throws if [upsert] fails.
-  Future<bool> upsertAndExportInline({
-    required String messageId,
-    required Future<void> Function() upsert,
-  }) async {
-    Future<bool> run() async {
-      await upsert();
-      final settle = _settleAfterUpsert();
-      if (settle > Duration.zero) {
-        await Future<void>.delayed(settle);
-      }
-      return FileExportPipeline.instance.exportNow(messageId);
-    }
-
-    final prev = _tail ?? Future<void>.value();
-    late final Future<bool> next;
-    next = prev.then((_) => run());
-    _tail = next.then((_) {}).catchError((Object e, StackTrace st) {
-      _log.warning(
-        'ReceivedFileIndexPipeline failed for $messageId: $e',
-        e,
-        st,
-      );
-    });
-    return next;
-  }
-}
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+
+import '../logger.dart';
+import 'file_export_pipeline.dart';
+import 'received_file_dao.dart';
+
+final _log = logChat;
+
+/// Brief pause after index write so cache files finish flushing before export.
+Duration _settleAfterUpsert() {
+  if (kIsWeb) return Duration.zero;
+  if (Platform.isWindows || Platform.isMacOS || Platform.isLinux) {
+    return const Duration(milliseconds: 50);
+  }
+  return const Duration(milliseconds: 50);
+}
+
+/// Serializes [ReceivedFileDao.upsert] + inline [FileExportPipeline.exportNow]
+/// so each received file is exported before the next finalize runs.
+class ReceivedFileIndexPipeline {
+  ReceivedFileIndexPipeline._();
+  static final instance = ReceivedFileIndexPipeline._();
+
+  Future<void>? _tail;
+
+  /// Runs [task] after all prior pipeline work completes.
+  Future<T> enqueue<T>(Future<T> Function() task) {
+    final prev = _tail ?? Future<void>.value();
+    late final Future<T> next;
+    next = prev.then((_) => task());
+    _tail = next.then((_) {}).catchError((Object e, StackTrace st) {
+      _log.warning(
+        'ReceivedFileIndexPipeline task failed: $e',
+        e,
+        st,
+      );
+    });
+    return next;
+  }
+
+  /// Runs [upsert] then immediately exports to visible storage.
+  /// Returns `true` when export reaches [ExportStatus.done].
+  /// Throws if [upsert] fails.
+  Future<bool> upsertAndExportInline({
+    required String messageId,
+    required Future<void> Function() upsert,
+  }) {
+    return enqueue(() async {
+      await upsert();
+      final settle = _settleAfterUpsert();
+      if (settle > Duration.zero) {
+        await Future<void>.delayed(settle);
+      }
+      return FileExportPipeline.instance.exportNow(messageId);
+    });
+  }
+
+  /// Re-keys a received_files row after LAN/WebRTC bubble id upgrade.
+  /// Must run on the same queue as inline export so export status is preserved.
+  Future<bool> rekeyAfterBubbleUpgrade({
+    required String oldMessageId,
+    required String newMessageId,
+    String? userId,
+    String? threadKey,
+    String? fromDeviceId,
+  }) {
+    return enqueue(
+      () => ReceivedFileDao.instance.rekeyMessageId(
+        oldMessageId: oldMessageId,
+        newMessageId: newMessageId,
+        userId: userId,
+        threadKey: threadKey,
+        fromDeviceId: fromDeviceId,
+      ),
+    );
+  }
+}

--- a/app/test/received_file_dao_reconcile_test.dart
+++ b/app/test/received_file_dao_reconcile_test.dart
@@ -134,4 +134,66 @@ void main() {
       expect(record.absPath, cacheFile.path);
     });
   });
+
+  group('ReceivedFileDao.rekeyMessageId', () {
+    late Database db;
+
+    setUp(() async {
+      db = await openDatabase(
+        inMemoryDatabasePath,
+        version: 1,
+        onCreate: (database, version) async {
+          await database.execute(_createReceivedFiles);
+        },
+      );
+      ReceivedFileDao.testDatabase = db;
+    });
+
+    tearDown(() async {
+      ReceivedFileDao.testDatabase = null;
+      await db.close();
+    });
+
+    test('preserves export fields when re-keying to server message id', () async {
+      const oldId = 'lan_recv_local';
+      const newId = '1781146674038_android_abc';
+      const visiblePath = '/storage/Downloads/photo.jpg';
+
+      await ReceivedFileDao.instance.upsert(
+        messageId: oldId,
+        absPath: '/cache/photo.jpg',
+        cachePath: '/cache/photo.jpg',
+        protocol: 'lan',
+        exportStatus: ExportStatus.done,
+      );
+      await ReceivedFileDao.instance.updateExportState(
+        messageId: oldId,
+        exportStatus: ExportStatus.done,
+        visiblePath: visiblePath,
+        exportTarget: ExportTargetKind.downloads,
+        gallerySaved: false,
+        absPath: visiblePath,
+        clearCachePath: true,
+      );
+
+      final ok = await ReceivedFileDao.instance.rekeyMessageId(
+        oldMessageId: oldId,
+        newMessageId: newId,
+        userId: '1',
+        threadKey: 'u:1',
+        fromDeviceId: 'android_device',
+      );
+      expect(ok, isTrue);
+
+      expect(await ReceivedFileDao.instance.getByMessageId(oldId), isNull);
+      final record = await ReceivedFileDao.instance.getByMessageId(newId);
+      expect(record, isNotNull);
+      expect(record!.exportStatus, ExportStatus.done);
+      expect(record.visiblePath, visiblePath);
+      expect(record.exportTarget, ExportTargetKind.downloads);
+      expect(record.userId, '1');
+      expect(record.threadKey, 'u:1');
+      expect(record.fromDeviceId, 'android_device');
+    });
+  });
 }


### PR DESCRIPTION
Serialize received_files re-key with inline export, preserve export state on message id upgrade, and only delete cache after a successful done write.