### PR TITLE
Move desktop SQLite database to Application Support.

### DIFF
--- a/app/lib/services/database.dart
+++ b/app/lib/services/database.dart
@@ -129,19 +129,27 @@ class AppDatabase {
     await _migrateTransferRecordsFromPrefs();
   }
 
-  /// iOS keeps SQLite in Application Support so it does not appear in Files app.
+  /// iOS and desktop keep SQLite in Application Support so it is not user-visible
+  /// (iOS Files app / desktop Documents folder).
+  static bool get _usesApplicationSupportDatabase =>
+      Platform.isIOS ||
+      Platform.isWindows ||
+      Platform.isLinux ||
+      Platform.isMacOS;
+
   Future<String> _resolveDatabasePath() async {
-    if (Platform.isIOS) {
+    if (_usesApplicationSupportDatabase) {
       final supportDir = await getApplicationSupportDirectory();
+      await Directory(supportDir.path).create(recursive: true);
       final dbPath = join(supportDir.path, 'ultrasend.db');
-      await _migrateIosDatabaseFromDocuments(dbPath);
+      await _migrateDatabaseFromDocuments(dbPath);
       return dbPath;
     }
     final dir = await getApplicationDocumentsDirectory();
     return join(dir.path, 'ultrasend.db');
   }
 
-  Future<void> _migrateIosDatabaseFromDocuments(String newPath) async {
+  Future<void> _migrateDatabaseFromDocuments(String newPath) async {
     final docsDir = await getApplicationDocumentsDirectory();
     final oldPath = join(docsDir.path, 'ultrasend.db');
     final oldFile = File(oldPath);

--- a/docs/ios-files-app-visibility.md
+++ b/docs/ios-files-app-visibility.md
@@ -18,8 +18,8 @@
 ### 应用保存路径
 
 - 默认根目录：`getApplicationDocumentsDirectory()` + `Downloads`
-- SQLite 数据库：`getApplicationSupportDirectory()` + `ultrasend.db`（不在「文件」App 中显示）
-- 解析逻辑：[`app/lib/services/receive_dir_resolver.dart`](../app/lib/services/receive_dir_resolver.dart)
+- SQLite 数据库：`getApplicationSupportDirectory()` + `ultrasend.db`（不在「文件」App 中显示；桌面端同样不在用户「文档」目录中显示，避免误删）
+- 解析逻辑：[`app/lib/services/receive_dir_resolver.dart`](../app/lib/services/receive_dir_resolver.dart)、[`app/lib/services/database.dart`](../app/lib/services/database.dart)
 - 主入口：[`FileStore.getReceiveDir()`](../app/lib/services/file_store.dart)
 
 在「文件」中的路径示例：


### PR DESCRIPTION
Avoid placing ultrasend.db in the user-visible Documents folder on PC, and auto-migrate existing databases on upgrade.