### PR TITLE
feat: 支持粘贴剪贴板截图到待发文件箱

### DIFF
--- a/app/lib/services/desktop_file_clipboard.dart
+++ b/app/lib/services/desktop_file_clipboard.dart
@@ -2,8 +2,11 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:pasteboard/pasteboard.dart';
+import 'package:uuid/uuid.dart';
 
+import '../utils/clipboard_image.dart';
 import '../utils/runtime_platform.dart';
+import 'file_store.dart';
 
 /// Desktop-only file clipboard read/write via [Pasteboard].
 final class DesktopFileClipboard {
@@ -11,11 +14,18 @@ final class DesktopFileClipboard {
 
   /// Reads file paths from the system clipboard and returns [PlatformFile]s
   /// suitable for the pending outbox. Empty on non-desktop or when no files.
+  ///
+  /// When no file paths are present (e.g. a screenshot copied by a capture
+  /// tool), falls back to reading raw clipboard image bytes and staging them
+  /// into the cache so they can be sent like any other file.
   static Future<List<PlatformFile>> readFilesForPending() async {
     if (!RuntimePlatform.isDesktop) return const [];
 
     final paths = await Pasteboard.files();
-    if (paths.isEmpty) return const [];
+    if (paths.isEmpty) {
+      final image = await _readImageForPending();
+      return image == null ? const [] : [image];
+    }
 
     final files = <PlatformFile>[];
     for (final p in paths) {
@@ -32,6 +42,24 @@ final class DesktopFileClipboard {
       );
     }
     return files;
+  }
+
+  /// Stages clipboard image bytes (a screenshot) into the cache as a file.
+  static Future<PlatformFile?> _readImageForPending() async {
+    final bytes = await Pasteboard.image;
+    if (bytes == null || bytes.isEmpty) return null;
+
+    final ext = extensionForImageBytes(bytes);
+    final name = clipboardImageFileName(ext: ext);
+    final destPath = await FileStore.buildCachePath(
+      'clipboard_${const Uuid().v4()}',
+      name,
+    );
+    final file = File(destPath);
+    await file.writeAsBytes(bytes, flush: true);
+    final stat = await file.stat();
+    if (stat.size <= 0) return null;
+    return PlatformFile(name: name, path: destPath, size: stat.size);
   }
 
   /// Writes local file paths to the system clipboard. Returns false on

--- a/app/lib/utils/clipboard_image.dart
+++ b/app/lib/utils/clipboard_image.dart
@@ -1,0 +1,58 @@
+import 'dart:typed_data';
+
+/// Infers a file extension (without dot) from image [bytes] magic numbers.
+///
+/// Falls back to `png` when the format is unrecognized, since clipboard
+/// screenshots on most platforms are exposed as PNG.
+String extensionForImageBytes(Uint8List bytes) {
+  if (bytes.length >= 8 &&
+      bytes[0] == 0x89 &&
+      bytes[1] == 0x50 &&
+      bytes[2] == 0x4E &&
+      bytes[3] == 0x47 &&
+      bytes[4] == 0x0D &&
+      bytes[5] == 0x0A &&
+      bytes[6] == 0x1A &&
+      bytes[7] == 0x0A) {
+    return 'png';
+  }
+  if (bytes.length >= 3 &&
+      bytes[0] == 0xFF &&
+      bytes[1] == 0xD8 &&
+      bytes[2] == 0xFF) {
+    return 'jpg';
+  }
+  if (bytes.length >= 6 &&
+      bytes[0] == 0x47 &&
+      bytes[1] == 0x49 &&
+      bytes[2] == 0x46 &&
+      bytes[3] == 0x38 &&
+      (bytes[4] == 0x37 || bytes[4] == 0x39) &&
+      bytes[5] == 0x61) {
+    return 'gif';
+  }
+  if (bytes.length >= 2 && bytes[0] == 0x42 && bytes[1] == 0x4D) {
+    return 'bmp';
+  }
+  if (bytes.length >= 12 &&
+      bytes[0] == 0x52 &&
+      bytes[1] == 0x49 &&
+      bytes[2] == 0x46 &&
+      bytes[3] == 0x46 &&
+      bytes[8] == 0x57 &&
+      bytes[9] == 0x45 &&
+      bytes[10] == 0x42 &&
+      bytes[11] == 0x50) {
+    return 'webp';
+  }
+  return 'png';
+}
+
+/// Builds a screenshot-style file name like `Screenshot-20250616-143052.png`.
+String clipboardImageFileName({required String ext, DateTime? now}) {
+  final t = now ?? DateTime.now();
+  String two(int v) => v.toString().padLeft(2, '0');
+  final stamp =
+      '${t.year}${two(t.month)}${two(t.day)}-${two(t.hour)}${two(t.minute)}${two(t.second)}';
+  return 'Screenshot-$stamp.$ext';
+}

--- a/app/test/clipboard_image_test.dart
+++ b/app/test/clipboard_image_test.dart
@@ -1,0 +1,62 @@
+import 'dart:typed_data';
+
+import 'package:app/utils/clipboard_image.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('extensionForImageBytes', () {
+    test('detects PNG', () {
+      final bytes = Uint8List.fromList([
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00,
+      ]);
+      expect(extensionForImageBytes(bytes), 'png');
+    });
+
+    test('detects JPEG', () {
+      final bytes = Uint8List.fromList([0xFF, 0xD8, 0xFF, 0xE0, 0x00]);
+      expect(extensionForImageBytes(bytes), 'jpg');
+    });
+
+    test('detects GIF', () {
+      final bytes = Uint8List.fromList([
+        0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x00,
+      ]);
+      expect(extensionForImageBytes(bytes), 'gif');
+    });
+
+    test('detects BMP', () {
+      final bytes = Uint8List.fromList([0x42, 0x4D, 0x00, 0x00]);
+      expect(extensionForImageBytes(bytes), 'bmp');
+    });
+
+    test('detects WebP', () {
+      final bytes = Uint8List.fromList([
+        0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+      ]);
+      expect(extensionForImageBytes(bytes), 'webp');
+    });
+
+    test('falls back to png on unknown bytes', () {
+      final bytes = Uint8List.fromList([0x01, 0x02, 0x03, 0x04]);
+      expect(extensionForImageBytes(bytes), 'png');
+    });
+  });
+
+  group('clipboardImageFileName', () {
+    test('formats timestamped name with extension', () {
+      final name = clipboardImageFileName(
+        ext: 'png',
+        now: DateTime(2025, 6, 16, 14, 30, 52),
+      );
+      expect(name, 'Screenshot-20250616-143052.png');
+    });
+
+    test('uses provided extension', () {
+      final name = clipboardImageFileName(
+        ext: 'jpg',
+        now: DateTime(2025, 1, 2, 3, 4, 5),
+      );
+      expect(name, 'Screenshot-20250102-030405.jpg');
+    });
+  });
+}

--- a/web/src/components/chat/MessageInput.tsx
+++ b/web/src/components/chat/MessageInput.tsx
@@ -7,6 +7,7 @@ import { useSendShortcutMode } from '@/hooks/useSendShortcutMode';
 import { isMacPlatform } from '@/lib/shortcutPreferences';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { extractClipboardFiles } from '@/lib/clipboardFiles';
 import { CirclePlus, Send, X } from 'lucide-react';
 
 export function MessageInput() {
@@ -15,6 +16,7 @@ export function MessageInput() {
     sendTextMessage,
     sending,
     handleFileSelect,
+    addPendingFiles,
     selectedDeviceId,
   } = useChatContext();
 
@@ -62,6 +64,13 @@ export function MessageInput() {
           <textarea
             value={input}
             onChange={(e) => setInput(e.target.value)}
+            onPaste={(e) => {
+              if (disabled) return;
+              const files = extractClipboardFiles(e.clipboardData);
+              if (files.length === 0) return;
+              e.preventDefault();
+              addPendingFiles(files);
+            }}
             onKeyDown={(e) => {
               if (e.key !== 'Enter' || e.nativeEvent.isComposing) return;
               const shouldSend =

--- a/web/src/contexts/ChatContext.tsx
+++ b/web/src/contexts/ChatContext.tsx
@@ -130,6 +130,7 @@ export type ChatContextValue = {
   setPendingFiles: React.Dispatch<React.SetStateAction<File[]>>;
   handleSendFiles: () => void;
   handleFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  addPendingFiles: (files: File[]) => void;
   removePendingFile: (index: number) => void;
 
   // Message management
@@ -1690,14 +1691,19 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     }
   }, [pendingFiles, sendMode, selectedDeviceId, devices, webrtcAvailable, selectedTargets, otherDevices, lanDevices, deviceReach, sendFileToTargets, buildFreshLanDevices]);
 
+  const addPendingFiles = useCallback((files: File[]) => {
+    if (files.length === 0) return;
+    setFileError(null);
+    setPendingFiles((prev) => [...prev, ...files]);
+  }, []);
+
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const fileList = e.target.files;
     if (!fileList || fileList.length === 0) return;
     const files = Array.from(fileList);
     e.target.value = '';
-    setFileError(null);
-    setPendingFiles((prev) => [...prev, ...files]);
-  }, []);
+    addPendingFiles(files);
+  }, [addPendingFiles]);
 
   const removePendingFile = useCallback((index: number) => {
     setPendingFiles((prev) => prev.filter((_, i) => i !== index));
@@ -1976,6 +1982,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     setPendingFiles,
     handleSendFiles,
     handleFileSelect,
+    addPendingFiles,
     removePendingFile,
     handleDeleteMessage,
     cancelTransfer,
@@ -2003,7 +2010,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     deviceReach, targetsProbing, refreshSendTargets, probeSingleDevice,
     runSessionConnectionDiagnostic, connectionDiagnostic, diagnosticSheetOpen, setDiagnosticSheetOpen,
     messages, sendTextMessage, sending, sendError, fileError,
-    pendingFiles, handleSendFiles, handleFileSelect, removePendingFile,
+    pendingFiles, handleSendFiles, handleFileSelect, addPendingFiles, removePendingFile,
     handleDeleteMessage, cancelTransfer, handleRetryText, handleRetryFile,
     loadMoreMessages, loadingMore,
     selectMode, selectedKeys, toggleMessageSelect, exitSelectMode, toggleSelectAllMessages, enterSelectWithKey, handleBulkDelete, clearCurrentThreadMessages,

--- a/web/src/lib/clipboardFiles.ts
+++ b/web/src/lib/clipboardFiles.ts
@@ -1,0 +1,53 @@
+/** Extract pasteable / droppable files from a DataTransfer (clipboard or drop). */
+
+const GENERIC_IMAGE_NAMES = new Set(['image.png', 'image', 'blob', '']);
+
+function screenshotName(type: string): string {
+  const ext = type.split('/')[1]?.split('+')[0] || 'png';
+  const t = new Date();
+  const two = (v: number) => String(v).padStart(2, '0');
+  const stamp = `${t.getFullYear()}${two(t.getMonth() + 1)}${two(t.getDate())}-${two(t.getHours())}${two(t.getMinutes())}${two(t.getSeconds())}`;
+  return `Screenshot-${stamp}.${ext}`;
+}
+
+/**
+ * Collects files from clipboard/drop data, normalizing screenshots that arrive
+ * with a generic name (e.g. `image.png`) into a timestamped `Screenshot-*` file.
+ */
+export function extractClipboardFiles(data: DataTransfer): File[] {
+  const out: File[] = [];
+  const seen = new Set<string>();
+
+  const consider = (file: File | null) => {
+    if (!file || file.size <= 0) return;
+    let result = file;
+    if (
+      file.type.startsWith('image/') &&
+      GENERIC_IMAGE_NAMES.has(file.name.toLowerCase())
+    ) {
+      result = new File([file], screenshotName(file.type), {
+        type: file.type,
+        lastModified: file.lastModified,
+      });
+    }
+    const key = `${result.name}_${result.size}_${result.lastModified}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push(result);
+  };
+
+  if (data.items && data.items.length > 0) {
+    for (const item of Array.from(data.items)) {
+      if (item.kind !== 'file') continue;
+      consider(item.getAsFile());
+    }
+  }
+
+  if (out.length === 0 && data.files && data.files.length > 0) {
+    for (const file of Array.from(data.files)) {
+      consider(file);
+    }
+  }
+
+  return out;
+}


### PR DESCRIPTION
桌面端 Cmd/Ctrl+V 在无文件路径时回退读取剪贴板图片字节，
按 magic number 推断格式并写入 cache 暂存；Web 聊天输入框
新增 onPaste，将截图/图片加入 pendingFiles。