### PR TITLE
fix: 修复 Windows 跨盘迁移数据库导致 1.4.8 启动白屏

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -92,15 +92,65 @@ Future<void> _injectLetsEncryptRootCa() async {
 
 void main(List<String> args) async {
   HttpOverrides.global = _NoProxyHttpOverrides();
-  WidgetsFlutterBinding.ensureInitialized();
+  // Run the whole startup inside a guarded zone so async errors thrown before
+  // the first frame cannot silently abort main() into a blank window.
+  // ensureInitialized() and runApp() must live in the same zone.
+  runZonedGuarded<Future<void>>(
+    () async {
+      WidgetsFlutterBinding.ensureInitialized();
+      // Logging first: any failure during the rest of boot must reach the log
+      // file on disk. Otherwise a crash before the first frame is a silent
+      // white screen with no diagnostics (cf. 1.4.8 Windows white-screen).
+      await AppLogFile.instance.init();
+      initLogging();
+      _installBootErrorHandlers();
+      try {
+        await _bootstrap(args);
+      } catch (e, st) {
+        logBoot.severe('fatal boot error before first frame: $e', e, st);
+        runApp(
+          BootFailureApp(
+            error: e,
+            stackTrace: st,
+            logFilePath: AppLogFile.instance.currentLogFilePath,
+          ),
+        );
+      }
+    },
+    (error, stack) {
+      logBoot.severe('uncaught zone error: $error', error, stack);
+    },
+  );
+}
+
+/// Routes framework + platform-dispatcher errors into the on-disk log so a
+/// release build that white-screens still leaves a diagnosable trail.
+void _installBootErrorHandlers() {
+  final previousOnError = FlutterError.onError;
+  FlutterError.onError = (FlutterErrorDetails details) {
+    logBoot.severe(
+      'FlutterError: ${details.exceptionAsString()}',
+      details.exception,
+      details.stack,
+    );
+    previousOnError?.call(details);
+  };
+  WidgetsBinding.instance.platformDispatcher.onError = (error, stack) {
+    logBoot.severe('PlatformDispatcher uncaught error: $error', error, stack);
+    return true;
+  };
+}
+
+/// App startup sequence. Runs inside [runZonedGuarded] with logging already
+/// initialized, so any thrown error is captured and surfaced via
+/// [BootFailureApp] instead of producing a blank window.
+Future<void> _bootstrap(List<String> args) async {
   FlutterForegroundTask.initCommunicationPort();
   await TransferKeepAlive.ensureInitialized();
   await TransferCompletionNotifier.ensureInitialized();
   if (!Platform.isWindows) {
     await LiquidGlassWidgets.initialize();
   }
-  await AppLogFile.instance.init();
-  initLogging();
   await _injectLetsEncryptRootCa();
   final launchedAtStartup = WindowsLaunchAtStartupService.isStartupLaunch(args);
   if (Platform.isWindows) {
@@ -252,10 +302,105 @@ void main(List<String> args) async {
         : LiquidGlassWidgets.wrap(adaptiveQuality: false, child: appRoot),
   );
 
+  // Distinguishes "first frame rendered" from "main() reached runApp but the
+  // rasterizer never painted" when triaging white-screen reports.
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    logBoot.info('first frame rendered');
+  });
+
   if (desktopTraySupported) {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       initDesktopTrayAfterFirstFrame();
     });
+  }
+}
+
+/// Minimal, theme-independent screen shown when startup fails before the app
+/// UI can render. Replaces a silent white window with the error, stack trace
+/// and log-file path so users can screenshot or send it to support.
+class BootFailureApp extends StatelessWidget {
+  const BootFailureApp({
+    super.key,
+    required this.error,
+    required this.stackTrace,
+    this.logFilePath,
+  });
+
+  final Object error;
+  final StackTrace stackTrace;
+  final String? logFilePath;
+
+  @override
+  Widget build(BuildContext context) {
+    final buffer = StringBuffer()
+      ..writeln('启动失败 / Startup failed')
+      ..writeln()
+      ..writeln(error.toString())
+      ..writeln()
+      ..writeln(stackTrace.toString());
+    if (logFilePath != null) {
+      buffer
+        ..writeln()
+        ..writeln('日志文件 / Log file:')
+        ..writeln(logFilePath);
+    }
+    final text = buffer.toString();
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: Scaffold(
+        backgroundColor: const Color(0xFF1A1A1A),
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  '应用启动失败',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  '请截图本页面或把日志文件发给开发者协助排查。',
+                  style: TextStyle(color: Colors.white70, fontSize: 13),
+                ),
+                const SizedBox(height: 12),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: OutlinedButton(
+                    onPressed: () {
+                      Clipboard.setData(ClipboardData(text: text));
+                    },
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: Colors.white,
+                      side: const BorderSide(color: Colors.white54),
+                    ),
+                    child: const Text('复制错误信息'),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: SelectableText(
+                      text,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 12,
+                        fontFamily: 'monospace',
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/app/lib/services/database.dart
+++ b/app/lib/services/database.dart
@@ -9,6 +9,7 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart'
 
 import 'transfer_record.dart';
 import '../chat/thread_key.dart';
+import '../logger.dart';
 
 const _dbVersion = 7;
 
@@ -150,16 +151,41 @@ class AppDatabase {
   }
 
   Future<void> _migrateDatabaseFromDocuments(String newPath) async {
-    final docsDir = await getApplicationDocumentsDirectory();
-    final oldPath = join(docsDir.path, 'ultrasend.db');
-    final oldFile = File(oldPath);
-    if (!await oldFile.exists() || await File(newPath).exists()) return;
+    try {
+      final docsDir = await getApplicationDocumentsDirectory();
+      final oldPath = join(docsDir.path, 'ultrasend.db');
+      final oldFile = File(oldPath);
+      if (!await oldFile.exists() || await File(newPath).exists()) return;
 
-    await oldFile.rename(newPath);
-    for (final suffix in const ['-wal', '-shm']) {
-      final sidecar = File('$oldPath$suffix');
-      if (await sidecar.exists()) {
-        await sidecar.rename('$newPath$suffix');
+      await _moveFileAcrossVolumes(oldFile, newPath);
+      for (final suffix in const ['-wal', '-shm']) {
+        final sidecar = File('$oldPath$suffix');
+        if (await sidecar.exists()) {
+          await _moveFileAcrossVolumes(sidecar, '$newPath$suffix');
+        }
+      }
+    } catch (e, st) {
+      // Never let a migration failure block startup. Worst case the app starts
+      // with a fresh DB at the new location; the old file is left untouched and
+      // can be recovered manually.
+      logBoot.warning('AppDatabase migrate from Documents failed: $e', e, st);
+    }
+  }
+
+  /// Moves [file] to [destPath]. Uses [File.rename] when possible, falling back
+  /// to copy+delete when source and destination live on different volumes
+  /// (rename throws `FileSystemException` / OS error 17 across drives on
+  /// Windows, e.g. Documents redirected to D: while AppData is on C:).
+  Future<void> _moveFileAcrossVolumes(File file, String destPath) async {
+    try {
+      await file.rename(destPath);
+    } on FileSystemException {
+      await file.copy(destPath);
+      try {
+        await file.delete();
+      } catch (_) {
+        // Source deletion is best-effort; the destination copy already exists,
+        // and re-migration is guarded by the destination-exists check.
       }
     }
   }

--- a/app/lib/services/transfer_completion_notifier.dart
+++ b/app/lib/services/transfer_completion_notifier.dart
@@ -16,8 +16,13 @@ class TransferCompletionNotifier {
   static const _channelId = 'transfer_completion';
   static const _notificationId = 257;
 
-  final FlutterLocalNotificationsPlugin _plugin =
-      FlutterLocalNotificationsPlugin();
+  // Lazily constructed and only ever touched on mobile (every caller is gated
+  // by RuntimePlatform.isMobile). This avoids resolving the desktop platform
+  // implementations of flutter_local_notifications on Windows/macOS/Linux,
+  // where they are unused.
+  FlutterLocalNotificationsPlugin? _pluginInstance;
+  FlutterLocalNotificationsPlugin get _plugin =>
+      _pluginInstance ??= FlutterLocalNotificationsPlugin();
 
   bool _initialized = false;
 

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.4.8+48
+version: 1.4.9+49
 
 environment:
   sdk: ^3.9.2
@@ -131,6 +131,10 @@ flutter:
     - assets/certs/isrg_root_x1.pem
 
   # BEGIN_WINDOWS_FONT
+  fonts:
+    - family: UltrasendWenYuanSansSC
+      fonts:
+        - asset: assets/fonts/windows/WenYuanSansSCVF.ttf
   # END_WINDOWS_FONT
 
 # Tobias 支付宝插件：iOS 回调需配置 url_scheme（不可含下划线）


### PR DESCRIPTION
Documents 在 D 盘而 AppData 在 C 盘时，rename 无法跨卷移动 ultrasend.db，启动在 AppDatabase.open 处抛错。改为 copy+delete 回退，迁移失败也不阻断启动；同时增加启动日志前置、全局错误捕获与启动失败兜底页，版本升至 1.4.9+49。