### PR TITLE
fix: 允许终身会员购买增购加油包

### DIFF
--- a/app/lib/screens/membership_screen.dart
+++ b/app/lib/screens/membership_screen.dart
@@ -118,7 +118,8 @@ class _MembershipScreenState extends ConsumerState<MembershipScreen> {
     // specific channel (Stripe / Apple / Google), route them there instead of letting
     // a second channel double-charge.
     final surface = _resolvePurchaseSurface(tier);
-    final decision = decideMembershipPurchase(me: _me, surface: surface);
+    final decision =
+        decideMembershipPurchase(me: _me, surface: surface, isAddon: tier.isAddon);
     if (!decision.canPurchase) {
       await _handleChannelLocked(decision);
       return;

--- a/app/lib/services/membership_channel_guard.dart
+++ b/app/lib/services/membership_channel_guard.dart
@@ -57,10 +57,20 @@ class MembershipChannelDecision {
 ///
 /// [surface] should reflect *where* the user clicked (e.g. desktop -> [PurchaseSurface.stripeWeb]
 /// for overseas, [PurchaseSurface.alipayPcWeb] for mainland).
+///
+/// [isAddon] marks one-shot add-on (device pack) purchases. Add-ons are
+/// channel-independent top-ups and must NOT be blocked by the upgrade
+/// channel-affinity guard (e.g. a mainland lifetime member can still buy
+/// add-on packs via Alipay).
 MembershipChannelDecision decideMembershipPurchase({
   required MembershipMe? me,
   required PurchaseSurface surface,
+  bool isAddon = false,
 }) {
+  if (isAddon) {
+    return MembershipChannelDecision.allow(surface);
+  }
+
   final channel = (me?.paymentChannel ?? PaymentChannel.free).toUpperCase();
 
   if (channel == PaymentChannel.free || (me?.canSwitchChannel ?? true)) {

--- a/app/test/membership_channel_guard_test.dart
+++ b/app/test/membership_channel_guard_test.dart
@@ -69,6 +69,21 @@ void main() {
       expect(d.reason, LockReason.lifetimeMainland);
     });
 
+    test('ALIPAY_LIFETIME can still buy add-on packs on any surface', () {
+      final me = _me(channel: PaymentChannel.alipayLifetime, canSwitch: false);
+      for (final s in PurchaseSurface.values) {
+        final d = decideMembershipPurchase(me: me, surface: s, isAddon: true);
+        expect(d.canPurchase, isTrue, reason: 'surface=$s');
+        expect(d.reason, LockReason.none, reason: 'surface=$s');
+      }
+
+      // Sanity: a non-addon purchase on the same user is still blocked.
+      final upgrade =
+          decideMembershipPurchase(me: me, surface: PurchaseSurface.stripeWeb);
+      expect(upgrade.canPurchase, isFalse);
+      expect(upgrade.reason, LockReason.lifetimeMainland);
+    });
+
     test('null me allows any surface (treated as FREE)', () {
       for (final s in PurchaseSurface.values) {
         expect(decideMembershipPurchase(me: null, surface: s).canPurchase, isTrue);


### PR DESCRIPTION
addon 购买此前被订阅升级的渠道亲和性校验误拦截，
终身会员(ALIPAY_LIFETIME)点击支付宝购买会弹出
"你已是终身会员，无需再升级订阅"并中止。

给 decideMembershipPurchase 增加 isAddon 参数，addon 购买
直接放行(渠道无关的一次性充值)，并补充对应单测。