### PR TITLE
fix: 完备化数据库启动容错并增加 boot 步骤日志

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -145,13 +145,19 @@ void _installBootErrorHandlers() {
 /// initialized, so any thrown error is captured and surfaced via
 /// [BootFailureApp] instead of producing a blank window.
 Future<void> _bootstrap(List<String> args) async {
+  // Step markers ('boot: ...'): on a hang or crash before the first frame, the
+  // last logged step localizes the failing init phase from the user's log.
+  logBoot.info('boot: begin (platform=${Platform.operatingSystem})');
   FlutterForegroundTask.initCommunicationPort();
   await TransferKeepAlive.ensureInitialized();
   await TransferCompletionNotifier.ensureInitialized();
+  logBoot.info('boot: keep-alive + notifier ready');
   if (!Platform.isWindows) {
     await LiquidGlassWidgets.initialize();
+    logBoot.info('boot: liquid glass initialized');
   }
   await _injectLetsEncryptRootCa();
+  logBoot.info('boot: root CA injected');
   final launchedAtStartup = WindowsLaunchAtStartupService.isStartupLaunch(args);
   if (Platform.isWindows) {
     try {
@@ -164,8 +170,10 @@ Future<void> _bootstrap(List<String> args) async {
   final localeRegionStore = LocaleRegionStore();
   await localeRegionStore.loadSync();
   await loadSendShortcutMode();
+  logBoot.info('boot: locale/region + shortcuts loaded');
 
   await OpenpanelBootstrap.initIfEligible();
+  logBoot.info('boot: openpanel init done');
 
   // 桌面更新 zip 内需含与 windows/CMakeLists.txt BINARY_NAME 一致的主程序（cn: 虾传.exe，intl: Shrimpsend.exe）。
   // MSIX/商店安装目录不可被 ZIP 覆盖，故不配置内置更新器（由商店负责更新）。
@@ -178,7 +186,9 @@ Future<void> _bootstrap(List<String> args) async {
       onError: (m) => logUpdate.warning(m),
     );
   }
+  logBoot.info('boot: opening database');
   await AppDatabase.instance.open();
+  logBoot.info('boot: database opened');
 
   if (Platform.isAndroid) {
     await SafStorageService.restorePersistedTreeUris();
@@ -193,6 +203,7 @@ Future<void> _bootstrap(List<String> args) async {
   final isLoggedIn = container.read(authProvider).isLoggedIn;
   final offlineWithoutLogin = await loadOfflineWithoutLogin();
   await localeRegionStore.applyLoggedInDefaultsIfNeeded(isLoggedIn);
+  logBoot.info('boot: auth/provider state loaded');
 
   final authSession = container.read(authSessionControllerProvider.notifier);
   authSession.onStorageLoaded(isLoggedIn: isLoggedIn);
@@ -271,6 +282,7 @@ Future<void> _bootstrap(List<String> args) async {
 
   if (desktopTraySupported) {
     await initDesktopWindowBeforeRunApp(startHidden: launchedAtStartup);
+    logBoot.info('boot: desktop window ready');
   }
 
   final themeStore = ThemeStore();
@@ -296,6 +308,7 @@ Future<void> _bootstrap(List<String> args) async {
   final desktopAppRoot = Platform.isWindows
       ? DesktopWindowCloseShortcuts(child: appRoot)
       : appRoot;
+  logBoot.info('boot: calling runApp');
   runApp(
     isDesktop
         ? desktopAppRoot

--- a/app/lib/services/database.dart
+++ b/app/lib/services/database.dart
@@ -120,13 +120,38 @@ class AppDatabase {
       sqfliteFfiInit();
       databaseFactory = databaseFactoryFfi;
     }
+
     final dbPath = await _resolveDatabasePath();
-    _db = await openDatabase(
-      dbPath,
-      version: _dbVersion,
-      onCreate: _onCreate,
-      onUpgrade: _onUpgrade,
-    );
+    if (dbPath != null) {
+      try {
+        _db = await openDatabase(
+          dbPath,
+          version: _dbVersion,
+          onCreate: _onCreate,
+          onUpgrade: _onUpgrade,
+        );
+        logBoot.info('AppDatabase opened at $dbPath');
+      } catch (e, st) {
+        logBoot.severe('AppDatabase open at $dbPath failed: $e', e, st);
+      }
+    } else {
+      logBoot.severe('AppDatabase: no writable storage directory available');
+    }
+
+    // Last-resort fallback: an in-memory database keeps the app launchable
+    // (no white screen) when no on-disk path can be opened. Data is not
+    // persisted for this session; only an in-memory open failure is fatal and
+    // bubbles up to the BootFailureApp error screen in main().
+    if (_db == null) {
+      _db = await openDatabase(
+        inMemoryDatabasePath,
+        version: _dbVersion,
+        onCreate: _onCreate,
+        onUpgrade: _onUpgrade,
+      );
+      logBoot.severe('AppDatabase running in-memory (degraded, not persisted)');
+    }
+
     await _migrateTransferRecordsFromPrefs();
   }
 
@@ -138,16 +163,42 @@ class AppDatabase {
       Platform.isLinux ||
       Platform.isMacOS;
 
-  Future<String> _resolveDatabasePath() async {
+  /// Resolves the on-disk database path, or null when no writable directory can
+  /// be obtained (caller then falls back to an in-memory database).
+  Future<String?> _resolveDatabasePath() async {
+    final dirPath = await _resolveStorageDirectory();
+    if (dirPath == null) return null;
+    final dbPath = join(dirPath, 'ultrasend.db');
+    // Migration only applies on platforms that moved the DB into Application
+    // Support; when forced onto Documents the source==dest early-return is a
+    // no-op, so this is safe to call unconditionally for those platforms.
     if (_usesApplicationSupportDatabase) {
-      final supportDir = await getApplicationSupportDirectory();
-      await Directory(supportDir.path).create(recursive: true);
-      final dbPath = join(supportDir.path, 'ultrasend.db');
       await _migrateDatabaseFromDocuments(dbPath);
-      return dbPath;
     }
-    final dir = await getApplicationDocumentsDirectory();
-    return join(dir.path, 'ultrasend.db');
+    return dbPath;
+  }
+
+  /// Returns a writable directory for the database using a fallback chain, so a
+  /// single failing path_provider lookup cannot block startup. On stripped-down
+  /// / redirected Windows installs `getApplicationSupportDirectory()` or
+  /// `getApplicationDocumentsDirectory()` can throw
+  /// `MissingPlatformDirectoryException`; trying the other one recovers most of
+  /// those cases. Returns null only when every candidate fails.
+  Future<String?> _resolveStorageDirectory() async {
+    final List<Future<Directory> Function()> candidates =
+        _usesApplicationSupportDatabase
+        ? [getApplicationSupportDirectory, getApplicationDocumentsDirectory]
+        : [getApplicationDocumentsDirectory, getApplicationSupportDirectory];
+    for (final getDir in candidates) {
+      try {
+        final dir = await getDir();
+        await Directory(dir.path).create(recursive: true);
+        return dir.path;
+      } catch (e, st) {
+        logBoot.warning('AppDatabase resolve storage dir failed: $e', e, st);
+      }
+    }
+    return null;
   }
 
   Future<void> _migrateDatabaseFromDocuments(String newPath) async {
@@ -193,26 +244,31 @@ class AppDatabase {
   static const _prefsKeyTransferRecords = 'transfer_records';
 
   Future<void> _migrateTransferRecordsFromPrefs() async {
-    final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getStringList(_prefsKeyTransferRecords);
-    if (raw == null || raw.isEmpty) return;
-    final db = _db!;
-    int migrated = 0;
-    for (final s in raw) {
-      try {
-        final record = TransferRecord.fromJsonString(s);
-        await db.insert(
-          'transfer_records',
-          record.toMap(),
-          conflictAlgorithm: ConflictAlgorithm.replace,
-        );
-        migrated++;
-      } catch (_) {
-        // skip malformed entries
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getStringList(_prefsKeyTransferRecords);
+      if (raw == null || raw.isEmpty) return;
+      final db = _db!;
+      int migrated = 0;
+      for (final s in raw) {
+        try {
+          final record = TransferRecord.fromJsonString(s);
+          await db.insert(
+            'transfer_records',
+            record.toMap(),
+            conflictAlgorithm: ConflictAlgorithm.replace,
+          );
+          migrated++;
+        } catch (_) {
+          // skip malformed entries
+        }
       }
-    }
-    if (migrated > 0) {
-      await prefs.remove(_prefsKeyTransferRecords);
+      if (migrated > 0) {
+        await prefs.remove(_prefsKeyTransferRecords);
+      }
+    } catch (e, st) {
+      // Never let the prefs->SQLite backfill block startup.
+      logBoot.warning('AppDatabase migrate transfer records failed: $e', e, st);
     }
   }
 


### PR DESCRIPTION
AppData 与 Documents 目录获取失败时按回退链继续尝试，磁盘打开失败则降级内存库，迁移与 prefs 回填均不阻断启动；同时在 _bootstrap 各关键步骤输出 boot: 标记日志，便于定位启动白屏卡点。