### PR TITLE
docs: 新增 Hacker News 冷启动执行包

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Something is broken or behaves unexpectedly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please redact any tokens or credentials from logs and screenshots.
+        For security vulnerabilities, do **not** open a public issue — see [SECURITY.md](../SECURITY.md).
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      multiple: true
+      options:
+        - iOS
+        - Android
+        - macOS
+        - Windows
+        - Linux
+        - Web
+        - HarmonyOS
+    validations:
+      required: true
+  - type: dropdown
+    id: instance
+    attributes:
+      label: Instance
+      options:
+        - Official hosted (shrimpsend.com)
+        - Official hosted (xiachuan.net)
+        - Self-hosted
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: App / build version
+      description: e.g. 1.4.9+49 (Settings > About), or the commit you built from
+    validations:
+      required: false
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: network
+    attributes:
+      label: Network context (if transfer-related)
+      description: Same LAN or across networks? Any firewall/VPN/NAT? Which transfer path did the connection diagnostic show (LAN / reverse pull / WebRTC / S3)?
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Redact tokens. For self-hosted, backend logs live under scripts/logs/.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/shrimpsend/shrimpsend/blob/main/SECURITY.md
+    about: Please report vulnerabilities privately. Do not open a public issue.
+  - name: Questions & discussion
+    url: https://github.com/shrimpsend/shrimpsend/discussions
+    about: Usage questions, ideas, and general discussion belong in Discussions.
+  - name: International hosted service
+    url: https://shrimpsend.com
+    about: Try the official hosted edition without self-hosting.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest an improvement or new capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do, and what gets in the way today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Transfer / protocol
+        - Clients (Flutter)
+        - Web
+        - Backend
+        - Self-hosting / docs
+        - Other
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/self_host_help.yml
+++ b/.github/ISSUE_TEMPLATE/self_host_help.yml
@@ -1,0 +1,40 @@
+name: Self-hosting help
+description: Trouble deploying or running your own ShrimpSend instance
+labels: ["self-hosting", "question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening, please check [docs/SELF_HOST.md](../docs/SELF_HOST.md) and the 5-minute Docker path in the [README](../README.md#try-it-in-5-minutes).
+  - type: dropdown
+    id: method
+    attributes:
+      label: Deployment method
+      options:
+        - Docker compose
+        - Local dev scripts (start-dev.sh)
+        - Bare metal (deploy.sh)
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Host OS / architecture
+      placeholder: e.g. Ubuntu 24.04 x86_64, macOS arm64
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What did you run and what happened?
+      description: Include the exact command and the error. Which service failed (MySQL :3306 / Centrifugo :8000 / backend :9000 / web :3000)? Redact secrets.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: From scripts/logs/ or `docker compose logs`. Redact tokens.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!--
+Thanks for contributing to ShrimpSend / 虾传.
+Every commit must be signed off (DCO): use `git commit -s`. See CONTRIBUTING.md and DCO.md.
+Keep one logical change per PR.
+-->
+
+## What and why
+
+<!-- What does this change do, and what problem does it solve? Link issues, e.g. Closes #123 -->
+
+## Area
+
+- [ ] `backend/` (Java / Spring Boot)
+- [ ] `web/` (Next.js)
+- [ ] `app/` (Flutter)
+- [ ] `shared/protocol*` (needs client + server alignment)
+- [ ] Docs / self-hosting
+- [ ] Other
+
+## How was this tested?
+
+<!-- Commands run and manual verification steps. e.g. ./gradlew test, npm run lint, flutter analyze -->
+
+## Checklist
+
+- [ ] One logical change; no unrelated refactors
+- [ ] No secrets, keys, or production config committed
+- [ ] Formatters/linters run for touched areas
+- [ ] All commits are signed off (`git commit -s`)
+- [ ] Licensed under AGPL-3.0-or-later

--- a/README.md
+++ b/README.md
@@ -39,10 +39,25 @@ This repository (**`shrimpsend`**) is the open-source codebase for **ShrimpSend*
 - **No install for recipients** — send directly to browsers and temporary devices when the other side cannot install software.
 - **Resume after disconnects** — large native client ↔ client transfers continue from the interrupted position instead of restarting from 0%.
 - **Works on restrictive networks** — server-assisted relay when hotel Wi‑Fi, campus networks, or carrier NAT block direct reachability.
-- **Breaks through one-way networks** — firewalls and NAT often allow traffic in only one direction (e.g. phone → PC works, PC → phone does not). After sign-in, the server coordinates reachability probes between your devices; if direct HTTP push fails, ShrimpSend automatically **reverse-pulls** the file from the reachable side, or falls back to WebRTC / S3 relay. See [shared/protocol.md](shared/protocol.md#反向拉取-reverse-pull).
+- **Breaks through one-way networks** — firewalls and NAT often allow traffic in only one direction (e.g. phone → PC works, PC → phone does not). After sign-in, the server coordinates reachability probes between your devices; if direct HTTP push fails, ShrimpSend automatically **reverse-pulls** the file from the reachable side, or falls back to WebRTC / S3 relay. See [shared/protocol.en.md](shared/protocol.en.md#reverse-pull).
 - **LAN-first, still built for speed** — prefer direct LAN / WebRTC on the same network; use relay or S3-compatible fallback only when needed.
 - **Real-time sync** — [Centrifugo](https://centrifugal.dev/) pushes updates to every signed-in client on channel `user#<userId>`.
 - **Self-host friendly** — run the full stack on your infrastructure under [AGPL-3.0-or-later](LICENSE); production secrets stay in private ops templates ([docs/SELF_HOST.md](docs/SELF_HOST.md)).
+
+## Try it in 5 minutes
+
+Bring up MySQL, Centrifugo, and the backend with Docker, then run the web client:
+
+```bash
+git clone https://github.com/shrimpsend/shrimpsend.git
+cd shrimpsend
+./scripts/setup-local-config.sh   # writes .env + config.docker.json from examples
+docker compose up -d              # MySQL :3306, Centrifugo :8000, backend :9000
+
+cd web && npm ci && npm run dev   # web client on :3000
+```
+
+Open http://localhost:3000, create an account on your own instance, and add a second device (or a second browser) to send your first message. Full options, troubleshooting, and bare-metal/production paths: [docs/SELF_HOST.md](docs/SELF_HOST.md).
 
 ## Screenshots
 
@@ -258,7 +273,8 @@ shrimpsend/
 | Topic | Document |
 |-------|----------|
 | Self-hosting | [docs/SELF_HOST.md](docs/SELF_HOST.md) |
-| Transfer protocol | [shared/protocol.md](shared/protocol.md) |
+| Transfer protocol (English summary) | [shared/protocol.en.md](shared/protocol.en.md) |
+| Transfer protocol (full, 中文) | [shared/protocol.md](shared/protocol.md) |
 | Contributing + DCO | [CONTRIBUTING.md](CONTRIBUTING.md), [DCO.md](DCO.md) |
 | Security disclosures | [SECURITY.md](SECURITY.md) |
 | Setup guide (Chinese) | [docs/README.zh-CN.md](docs/README.zh-CN.md) |

--- a/docs/RELEASE_NOTES_v1.4.9.md
+++ b/docs/RELEASE_NOTES_v1.4.9.md
@@ -1,0 +1,43 @@
+# ShrimpSend v1.4.9 — release notes (draft)
+
+Draft for the GitHub Release that anchors the Show HN launch. Fill the changelog bullets from `git log` before publishing, then create the release with a tag that matches the client version.
+
+> Publish with (after reviewing the bullets):
+>
+> ```bash
+> git tag -a v1.4.9 -m "ShrimpSend v1.4.9"
+> git push origin v1.4.9
+> gh release create v1.4.9 --title "ShrimpSend v1.4.9" --notes-file docs/RELEASE_NOTES_v1.4.9.md
+> ```
+
+## Highlights
+
+ShrimpSend is an AGPL-3.0 file and message transfer tool for your own devices. It is LAN-first, recovers across NAT and one-way firewalls via reverse pull, resumes large transfers after disconnects, and lets a browser temporarily join a device conversation. The full stack is self-hostable: Spring Boot + Centrifugo + MySQL + S3-compatible storage.
+
+This is the build referenced in the launch (`app/pubspec.yaml` version `1.4.9+49`).
+
+## What's in this release
+
+<!-- Replace these placeholders with real entries from: git log --oneline <previous-tag>..HEAD -->
+
+- Added: ...
+- Improved: ...
+- Fixed: ...
+
+## Platforms
+
+iOS, Android, macOS, Windows, Linux, Web, HarmonyOS.
+
+## Self-hosting
+
+Run the full stack on your own infrastructure under AGPL-3.0-or-later. See [docs/SELF_HOST.md](SELF_HOST.md) and the 5-minute Docker path in the [README](../README.md#try-it-in-5-minutes).
+
+## Transfer protocol
+
+LAN direct push, reverse pull, WebRTC P2P, and S3-compatible relay. English summary: [shared/protocol.en.md](../shared/protocol.en.md).
+
+## Links
+
+- Source: https://github.com/shrimpsend/shrimpsend
+- International hosted service: https://shrimpsend.com
+- License: AGPL-3.0-or-later ([LICENSE](../LICENSE)) · Enterprise: [LICENSE-Commercial.md](../LICENSE-Commercial.md)

--- a/marketing/hackernews/README.md
+++ b/marketing/hackernews/README.md
@@ -1,0 +1,42 @@
+# Hacker News cold-start kit
+
+Execution assets for the ShrimpSend Show HN launch. Goal: **GitHub attention** (stars, issues, forks, self-host attempts). Constraint: the maker can do English interaction for only ~2-3 hours on launch day, so the strategy leans on a long maker comment + pre-written FAQ + GitHub Discussions to keep answering after going offline.
+
+HN audience reads English and uses the international site ([shrimpsend.com](https://shrimpsend.com)); don't bring up the China edition unless asked.
+
+## One-line positioning
+
+> AGPL open-source cross-device file transfer: LAN-first, automatic reverse-pull across NAT / one-way firewalls, resume for large files, and a browser can temporarily join a device conversation.
+
+In HN minds: not "another cloud drive" — the cross-network upgrade to LocalSend, plus a self-hostable private device conversation.
+
+## Files
+
+| File | Use |
+|---|---|
+| [launch-day-playbook.md](launch-day-playbook.md) | Timing, titles, link target, minute-by-minute, reply priority, T-24h checklist |
+| [maker-comment.md](maker-comment.md) | The first comment to paste ~60s after posting |
+| [faq-responses.md](faq-responses.md) | Templates for the questions HN always asks |
+| [good-first-issues.md](good-first-issues.md) | 8 ready-to-file contributor issues |
+| [self-host-dry-run.md](self-host-dry-run.md) | Pre-launch test protocol so self-host doesn't break on the day |
+| [warmup-comment-bank.md](warmup-comment-bank.md) | Organic HN participation in the 2-3 weeks before |
+| [blog-reverse-pull.md](blog-reverse-pull.md) | Technical warm-up post on the differentiator |
+| [post-launch-followup.md](post-launch-followup.md) | D+0 to D+7, second-round content, metrics |
+
+## Repo changes that ship with this kit
+
+- [README](../../README.md#try-it-in-5-minutes): 5-minute Docker quickstart + English protocol link.
+- [shared/protocol.en.md](../../shared/protocol.en.md): English protocol summary (technical credibility anchor).
+- [docs/RELEASE_NOTES_v1.4.9.md](../../docs/RELEASE_NOTES_v1.4.9.md): release notes draft.
+- `.github/`: issue templates (bug / feature / self-host) + PR template.
+
+## Timeline
+
+1. **Weeks 1-2** — GitHub "star-ready" polish: README/GIF, 5-min try, English protocol, good first issues, Release, templates.
+2. **Weeks 2-3** — Warm-up: organic HN comments, the reverse-pull post, self-host dry run.
+3. **Week 4** — Show HN on Tue/Wed 21:00 Beijing, 2-3 hours of high-frequency replies.
+4. **D+0 to D+7** — Triage, FAQ, fast issue response, evaluate, plan round two.
+
+## Hard rules
+
+No bought upvotes, vote rings, or sock-puppets — HN detects it and the penalty is permanent. Lead with the technology, not pricing. Concede fair criticism and convert it into issues.

--- a/marketing/hackernews/blog-reverse-pull.md
+++ b/marketing/hackernews/blog-reverse-pull.md
@@ -1,0 +1,55 @@
+# Why reverse-pull beats retrying HTTP push on asymmetric NAT
+
+Draft technical post for the warm-up phase. Publish on GitHub Discussions or a dev blog 1-2 weeks before the Show HN, then link it from the maker comment. It is a standalone technical story, not a product pitch — keep it that way.
+
+---
+
+Most "send a file to my other device" tools assume that if two machines are on the same network, either one can open a connection to the other. On real networks, that assumption is wrong often enough to matter.
+
+## The asymmetry
+
+Put an Android phone and a Windows desktop on the same Wi-Fi. The phone can usually open a TCP connection to the desktop and POST a file. The reverse — the desktop connecting to the phone — frequently fails. The Windows firewall blocks inbound connections by default, mobile OSes aggressively restrict background listeners, and "the same Wi-Fi" may actually be two subnets bridged by a router that does not allow client-to-client traffic.
+
+So reachability is directional. `A -> B` working tells you nothing about `B -> A`.
+
+A naive transfer tool picks a direction (say, sender connects to receiver), and when that fails it retries, backs off, and eventually gives up with a timeout. The user sees "transfer failed" even though a perfectly good path existed — just in the other direction.
+
+## Reverse pull
+
+The fix is to stop insisting on who connects to whom. Separate two things:
+
+1. Which device has the bytes (the logical sender).
+2. Which device can accept an inbound connection right now (the reachable side).
+
+These do not have to be the same device.
+
+In ShrimpSend, after both devices are signed in, the server coordinates a quick reachability probe in both directions. Then:
+
+- If the receiver is reachable, the sender does a normal HTTP push (`POST /transfer`).
+- If the receiver is not reachable but the sender is, the protocol flips: the sender exposes the file at `GET /download?offerId=...`, and the receiver pulls it. With `Range` requests, the pull resumes after a drop instead of restarting.
+
+The bytes still flow from logical sender to logical receiver. Only the direction of the TCP connection changed — and that is the one thing the network actually cares about.
+
+```mermaid
+flowchart LR
+  subgraph push [Push fails]
+    PCx[Desktop] -. blocked .-> Phonex[Phone]
+  end
+  subgraph pull [Reverse pull works]
+    Phone[Phone] -->|GET /download| PC[Desktop]
+  end
+```
+
+## Why not just use WebRTC for everything?
+
+WebRTC with ICE handles a lot of NAT traversal and is the next fallback in the chain. But establishing a peer connection has setup cost and failure modes of its own, and on a plain LAN a direct HTTP transfer is simpler and faster. Reverse pull is a cheap win for the very common case where one HTTP direction is open and the other is not, before paying for WebRTC negotiation or relaying through S3.
+
+The full path order ends up being: HTTP direct push, HTTP reverse pull, WebRTC peer-to-peer, then S3-compatible relay as the last resort. Each step is only reached when the cheaper one cannot connect.
+
+## Takeaways
+
+- Treat reachability as directional. Probe both ways.
+- Decouple "who has the data" from "who can accept a connection."
+- Reverse pull turns a large class of "same network but won't connect" failures into successful transfers without WebRTC or a relay.
+
+The protocol details are documented at https://github.com/shrimpsend/shrimpsend/blob/main/shared/protocol.en.md. ShrimpSend is AGPL-3.0 and self-hostable if you want to poke at the implementation.

--- a/marketing/hackernews/faq-responses.md
+++ b/marketing/hackernews/faq-responses.md
@@ -1,0 +1,59 @@
+# FAQ response templates
+
+Pre-written answers to the questions HN reliably asks. Keep them as raw material: adapt to the exact wording of each comment, never paste the same canned text twice in one thread. Tone: factual, no hype, never disparage competitors. If you're offline, a teammate can use these to keep the thread alive.
+
+---
+
+## "How is this different from LocalSend?"
+
+LocalSend is excellent when every device is on a reachable LAN with the app installed. ShrimpSend targets the cases it doesn't: asymmetric/one-way connectivity (phone can reach PC but not vice versa), cross-network sends, resume after a disconnect, and joining from a browser on a machine where you can't install anything. The tradeoff is more moving parts (there's a coordinating server for the fallback chain), in exchange for working off the happy path. If your devices are always on a clean LAN, LocalSend may be all you need.
+
+## "How is this different from Syncthing?"
+
+Different model. Syncthing continuously syncs folders across devices; it's great for keeping directories identical. ShrimpSend is for explicit, one-shot-ish sends into a device conversation — "send this screenshot to my laptop now" rather than "keep these folders in sync forever." Many people use both.
+
+## "Why not Magic Wormhole / Pairdrop / Snapdrop?"
+
+Those are great for one-off transfers. ShrimpSend optimizes for repeated sends between *your* devices that persist in a conversation, plus resume and the cross-network fallback chain. If you just need to beam one file to someone once, wormhole is hard to beat.
+
+## "AGPL — what's the catch? Is this open-core?"
+
+No open-core split: the code you self-host is the same code that runs the hosted service. AGPL-3.0 means self-hosting for yourself or your organization is free; if you modify it and offer it as a network service to third parties, AGPL asks you to share your modifications. There's a separate commercial license only for orgs that can't comply with that (e.g. closed-source modified SaaS, OEM/white-label). Details: https://github.com/shrimpsend/shrimpsend/blob/main/LICENSE-Commercial.md
+
+## "Why should I trust you with my files?"
+
+You don't have to — self-host and your files never touch our servers. The code is open and auditable. On the hosted service, files move via presigned S3 URLs and text bodies are encrypted at rest. For maximum control, point it at your own S3-compatible storage or run the whole stack yourself.
+
+## "It's from China — data sovereignty / privacy?"
+
+The codebase is fully open and the international hosted edition (shrimpsend.com) runs on its own cluster, separate from the China edition (xiachuan.net). If sovereignty matters to you, self-host: the stack runs entirely on your own infrastructure and the source is the same as what we run.
+
+## "What about encryption / E2E?"
+
+Today, text bodies are encrypted at rest on the server and transport is TLS; same-LAN direct transfers don't traverse our servers at all. Full end-to-end encryption for relayed transfers isn't there yet — happy to discuss the design in an issue if that's a blocker for you. I'd rather be precise about what exists than overclaim.
+
+## "Does it cost money?"
+
+Free for 3 devices. Beyond that there are paid tiers (subscription internationally, one-time purchase in China) mostly for more devices and hosted upload quota. But if you're here for the open-source stack, self-hosting removes the limits entirely.
+
+## "Can I use my own S3 / storage?"
+
+Yes — you can point it at any S3-compatible endpoint instead of the hosted bucket. S3 is the fallback relay path, not the primary one; LAN/WebRTC are preferred when reachable.
+
+## "Show me the protocol / how reverse-pull works"
+
+English summary: https://github.com/shrimpsend/shrimpsend/blob/main/shared/protocol.en.md — covers HTTP push, reverse pull (with `Range`-based resume), WebRTC DataChannels, and the S3 multipart path. The short version: reachability is directional, so when the receiver can't accept a connection, the reachable side pulls instead of the sender pushing.
+
+## "Self-host didn't work for me"
+
+Sorry about that — which step and what error? There's a 5-minute Docker path in the README and a guide at docs/SELF_HOST.md. If you can open an issue with the command, your OS, and which service failed (MySQL :3306 / Centrifugo :8000 / backend :9000 / web :3000), I'll fix the docs or the bug. (Use this to drive a real-time doc fix during the launch window.)
+
+## "HarmonyOS? Why?"
+
+It's a real platform for part of our user base. It's not central to the HN story — the interesting parts are the transfer protocol and self-hosting. Happy to go deeper on those instead.
+
+## Tone reminders
+
+- Concede valid criticism immediately and turn it into an issue.
+- Never say "revolutionary," "best," or "simply." Describe behavior and tradeoffs.
+- Thank critics as much as fans — sharp questions are the most useful thing a launch gets.

--- a/marketing/hackernews/good-first-issues.md
+++ b/marketing/hackernews/good-first-issues.md
@@ -1,0 +1,54 @@
+# Good first issues — backlog for launch
+
+Eight contributor-friendly issues to file before the Show HN launch. A visible `good first issue` list converts HN traffic into contributors, not just stargazers.
+
+How to file (run from the repo, requires `gh auth login`):
+
+```bash
+gh label create "good first issue" --color 7057ff --description "Good for newcomers" --force
+gh issue create --title "<title>" --label "good first issue,<area>" --body "<body>"
+```
+
+Keep each issue small (under ~2 hours for a newcomer), with clear acceptance criteria and pointers to the relevant files. Do not assign them; let contributors claim them in a comment.
+
+---
+
+## 1. Docs: add a docker-compose troubleshooting section
+- Labels: `good first issue`, `documentation`, `self-hosting`
+- Why: the 5-minute path in the README is the first thing HN visitors try; common failures (port already in use, MySQL healthcheck timeout, missing `config.docker.json`) deserve a short FAQ.
+- Acceptance: a "Troubleshooting" subsection under the Docker instructions in [docs/SELF_HOST.md](../../docs/SELF_HOST.md) covering at least port conflicts, MySQL not ready, and where logs live.
+
+## 2. Docs: English walkthrough screenshots for first-run
+- Labels: `good first issue`, `documentation`
+- Why: README screenshots show the UI but not the first-run flow (sign up on your own instance, add a second device).
+- Acceptance: 3-4 annotated screenshots or a short numbered list under "Try it in 5 minutes" in [README.md](../../README.md).
+
+## 3. Web: copy-to-clipboard button on received text messages
+- Labels: `good first issue`, `web`, `enhancement`
+- Why: text/clipboard sending is a core use case; a one-click copy on the web client is a small, self-contained UI addition.
+- Acceptance: a copy button on text messages in the web chat view with a "copied" toast; lint passes (`npm run lint` in `web/`).
+
+## 4. Web: show the active transfer path in the UI
+- Labels: `good first issue`, `web`, `enhancement`
+- Why: the connection diagnostic already knows whether a transfer used LAN / reverse pull / WebRTC / S3; surfacing it as a small badge reinforces the product's differentiator.
+- Acceptance: a label/badge near the transfer indicating the path used.
+
+## 5. Backend: validate and document required environment variables on startup
+- Labels: `good first issue`, `backend`, `self-hosting`
+- Why: self-hosters hit confusing failures when an env var is missing; a clear startup check improves the first-run experience.
+- Acceptance: backend logs a clear, actionable message naming any missing required variable (e.g. datasource URL, Centrifugo keys) instead of failing deep in the stack.
+
+## 6. i18n: audit the English strings in the web client
+- Labels: `good first issue`, `web`, `i18n`
+- Why: the project is bilingual (zh/en); the English landing/app strings benefit from a native-speaker pass before HN traffic.
+- Acceptance: a PR fixing awkward or inconsistent English strings in `web/`, with before/after noted in the description.
+
+## 7. Repo: add a CONTRIBUTING quickstart for web-only contributors
+- Labels: `good first issue`, `documentation`
+- Why: many contributors only want to touch the web client and do not need the full backend/Flutter setup.
+- Acceptance: a short "Web-only setup" note in [CONTRIBUTING.md](../../CONTRIBUTING.md) pointing the web client at the official/your dev API.
+
+## 8. Protocol: add request/response examples to the English summary
+- Labels: `good first issue`, `documentation`
+- Why: [shared/protocol.en.md](../../shared/protocol.en.md) describes endpoints; concrete curl examples for `/probe`, `/transfer-status`, and a presigned upload make it easy to verify a self-hosted instance.
+- Acceptance: a short "Examples" section with copy-pasteable curl commands.

--- a/marketing/hackernews/launch-day-playbook.md
+++ b/marketing/hackernews/launch-day-playbook.md
@@ -1,0 +1,65 @@
+# Show HN launch-day playbook
+
+Everything needed to execute the post itself. Optimized for the constraint: you can only do English interaction for ~2-3 hours on launch day.
+
+## When
+
+| Beijing time | US Pacific | Why |
+|---|---|---|
+| Tue or Wed, 21:00-22:00 | ~6:00-7:00 AM PT | US morning HN peak; you stay interactive until ~24:00 Beijing |
+
+Avoid Monday (crowded), Friday afternoon PT, and US holidays.
+
+## Title (decide one before posting)
+
+1. `Show HN: ShrimpSend – AGPL cross-device file transfer with LAN-first and reverse-pull fallback`
+2. `Show HN: Open-source file transfer between your devices (resume, WebRTC, self-hostable)`
+3. `Show HN: When HTTP push fails, pull instead – AGPL device-to-device transfer`
+
+Rules: factual, `Show HN:` prefix, include at least one of `AGPL` / `self-hostable`. No hype words.
+
+## Link target
+
+- **Submission URL:** https://github.com/shrimpsend/shrimpsend (the goal is GitHub attention, so link the repo, not the landing page).
+- In the first comment, add: https://shrimpsend.com (to try) and the protocol doc (depth).
+
+## Minute-by-minute
+
+| T+ | Action |
+|---|---|
+| T-24h | Run the final pre-launch checklist below. |
+| T+0 | Submit the Show HN with the chosen title, URL = the repo. |
+| T+1 min | Paste the maker comment from [maker-comment.md](maker-comment.md). |
+| T+0 to T+3h | Refresh HN + GitHub notifications every few minutes. Reply by priority (below). |
+| Last 10 min online | Post a short note: "Heading offline for a bit — I'll keep replying in GitHub Discussions." |
+| After offline | Teammate (if any) monitors using [faq-responses.md](faq-responses.md); otherwise replies resume in Discussions. |
+
+Do **not** ask anyone to upvote, and do not submit from a brand-new account — use the account warmed up via [warmup-comment-bank.md](warmup-comment-bank.md).
+
+## Reply priority (your 2-3 hour window)
+
+1. **Technical scrutiny** (protocol, security, AGPL) → detailed answer + link to the doc. These set the tone of the whole thread.
+2. **"How does it compare to X?"** → use [faq-responses.md](faq-responses.md); never disparage the competitor.
+3. **Self-host got stuck** → fix the doc/bug live and reply with the fix or an issue link. Highest-leverage for the GitHub goal.
+4. **Feature requests** → "Good idea — filed as #NNN." Converts a comment into a tracked issue.
+5. **Praise** → brief thanks, point to star / self-host.
+
+## Pre-launch checklist (T-24h)
+
+- [ ] README has the 5-minute Docker quickstart and (ideally) a short demo GIF near the top.
+- [ ] A demo GIF/screenshot exists (record: pick device → drag file → connection diagnostic showing the path). If not ready, ship without it rather than with a broken image.
+- [ ] GitHub Release published (see [../../docs/RELEASE_NOTES_v1.4.9.md](../../docs/RELEASE_NOTES_v1.4.9.md)).
+- [ ] At least 5 `good first issue`s filed (see [good-first-issues.md](good-first-issues.md)).
+- [ ] GitHub Discussions enabled.
+- [ ] Issue/PR templates live (`.github/`).
+- [ ] At least 3 testers reached "first message sent" on a clean machine (see [self-host-dry-run.md](self-host-dry-run.md)).
+- [ ] shrimpsend.com signup/download flow works end to end.
+- [ ] Maker comment + FAQ finalized in English.
+- [ ] Calendar block set: post 21:00, comment 21:05, high-frequency replies until ~24:00 Beijing.
+- [ ] (Optional) An English-fluent teammate lined up to cover ~2 hours after you go offline.
+
+## What NOT to do
+
+- No bought upvotes, vote rings, or sock-puppets. HN detects this and the penalty is permanent.
+- Don't lead with pricing or App Store links — HN wants the tech; pricing goes in the FAQ if asked.
+- Don't argue defensively. Concede fair points and convert them into issues.

--- a/marketing/hackernews/maker-comment.md
+++ b/marketing/hackernews/maker-comment.md
@@ -1,0 +1,39 @@
+# Maker's first comment (paste within ~60s of posting)
+
+Post this as the first comment on the Show HN thread immediately after submitting. It does the heavy lifting while you are limited to ~2-3 hours online: it states what the thing is, why it exists, how it differs, and answers the questions HN always asks, so people can self-serve after you go offline.
+
+Edit the personal details (the "why I built it" paragraph) so it sounds like you, not a press release. Target length is ~900-1100 words.
+
+---
+
+Hi HN — I'm the maker of ShrimpSend, an AGPL-3.0 tool for sending text and files between your own devices. Repo: https://github.com/shrimpsend/shrimpsend
+
+**Why I built it.** I constantly move small things between my phone, laptop, and a locked-down work PC: a screenshot to annotate, an installer to hand to the machine next to me, a command I copied in a browser that I want on my phone. The usual options all felt wrong for this. Cloud drives and "upload, get a link, send the link to myself" are heavy for a 200 KB screenshot. LocalSend is great on a clean LAN, but it falls apart the moment the network is asymmetric — and in my experience that's most of the time.
+
+**The core idea: device conversations, not links.** You don't create a public share link. You pick one of your devices and send into that conversation — text, clipboard snippets, images, an installer, a video. Repeated sends feel natural because they all land in the same place, and a browser can temporarily join the conversation on a machine where you can't install anything.
+
+**What's actually different (vs LocalSend / AirDrop-style tools):**
+
+- Reachability is directional. On the same Wi-Fi a phone can usually POST to a desktop, but the desktop often can't connect back (Windows firewall, mobile listener limits, AP client isolation). When direct push fails, the server coordinates a probe and the reachable side does a **reverse pull** instead of giving up. This recovers a lot of "same network but won't connect" cases before paying for WebRTC.
+- **Resume** for large native-client transfers — continue from the interrupted offset instead of restarting at 0%.
+- A **fallback chain**, cheapest path first: HTTP direct push on the LAN → HTTP reverse pull → WebRTC P2P → S3-compatible relay. Each step is only reached when the cheaper one can't connect.
+- **Web client** so a guest/work machine can receive without installing anything.
+
+Protocol write-up (English): https://github.com/shrimpsend/shrimpsend/blob/main/shared/protocol.en.md
+
+**Stack.** Spring Boot (Java 17) + MySQL for the API, Centrifugo for realtime (WebSocket, pushes updates to all your signed-in devices), Next.js for the web client, Flutter for iOS/Android/macOS/Windows/Linux, plus a HarmonyOS client. The whole thing is self-hostable — there's a 5-minute Docker path in the README.
+
+**License.** AGPL-3.0-or-later. Self-hosting for yourself or your org is free and unrestricted under AGPL. There's a separate commercial license only for the cases AGPL doesn't cover (e.g. shipping a closed-source modified network service). I'm not trying to do an open-core bait-and-switch — the code you self-host is the same code that runs the hosted service.
+
+**Privacy.** When text is synced through the server, the message body is encrypted at rest; metadata (type, timestamp, conversation id) stays readable so sync works, and there's no server-side search over message bodies. Files move via presigned S3 URLs. If you self-host, all of it is on your own infrastructure.
+
+**Honest limitations:**
+
+- The full experience needs a native client; the web client is intentionally limited by what browsers allow.
+- Some enhanced paths (reverse pull, cross-network) require sign-in, because the server has to coordinate the probe. Pure same-LAN native transfers can work without an account.
+- There's an official hosted edition (shrimpsend.com international; a separate China edition), but you don't need it — self-host and you never touch our servers.
+- It's a young project; rough edges exist and I'd genuinely like to hear where it breaks for you.
+
+**What would help most:** try the self-host path and tell me where the docs fail you, open issues, and let me know whether reverse-pull is as useful for your setup as it is for mine. There are some `good first issue`s tagged if you want to poke at the code.
+
+I'll be around to answer questions for the next few hours. After that I'll keep replying in GitHub Discussions (https://github.com/shrimpsend/shrimpsend/discussions), so nothing gets dropped while I'm offline. Thanks for taking a look.

--- a/marketing/hackernews/post-launch-followup.md
+++ b/marketing/hackernews/post-launch-followup.md
@@ -1,0 +1,41 @@
+# Post-launch follow-up (D+0 to D+7 and beyond)
+
+A single HN spike does not equal sustained growth. Star retention comes from a steady release cadence and fast issue response. The first week converts launch attention into a real project.
+
+## Day-by-day
+
+| Day | Action |
+|---|---|
+| D+0 | Monitor HN + GitHub notifications. Fix self-host doc breakage live. Respond to every substantive comment. |
+| D+1 | If HN went well (>100 points), publish/refresh the GitHub Release notes to echo the features people asked about. Reply to overnight comments. |
+| D+2-3 | Turn the top HN questions into a tracked `docs/FAQ.md` or pinned GitHub Discussion. Triage and label every issue opened during the launch. |
+| D+4-7 | Respond to all new issues within 72 hours. Merge or comment on early PRs quickly — first-time contributors who get a fast response come back. |
+| D+7 | Review metrics (below) and decide whether to run a second-round technical post. |
+
+## Issue & PR SLA (the part that retains stars)
+
+- New issue: first response within 72 hours, even if it's just triage.
+- `good first issue` PRs: review within a few days; a stale newcomer PR is a lost contributor.
+- Keep labels tidy (`bug`, `enhancement`, `self-hosting`, `good first issue`) so the repo reads as actively maintained.
+
+## Second-round content (space at least 2 weeks after launch)
+
+Do not re-submit a Show HN. Instead, submit a regular HN post or share elsewhere:
+
+- "How we implement reverse-pull file transfer" — the deep version of [blog-reverse-pull.md](blog-reverse-pull.md).
+- "Self-hosting ShrimpSend in 10 minutes" — a polished walkthrough born from the dry-run fixes.
+
+## Metrics to evaluate (D+7)
+
+| Tier | HN result | GitHub 7-day delta | Read as |
+|---|---|---|---|
+| Over-target | Top 5, 300+ points | 500+ stars | Product + narrative + luck aligned |
+| On-target | Front page 4-8h, 80-150 points | 150-300 stars | Healthy result for an indie tool |
+| Acceptable | 30-80 points | 50-150 stars | Still real SEO + community value |
+| Needs review | <30 points | <50 stars | Re-examine title, first comment, README try-it friction |
+
+Also track quality signals, not just stars: number of self-host attempts that succeeded, issues opened by non-team accounts, and any PRs from first-time contributors. Those predict whether the project keeps growing after the spike fades.
+
+## Retro (write it down)
+
+After D+7, capture: which title/first-comment framing landed, which objection came up most, where self-host still tripped people, and the single biggest fix for next time. Feed it back into the README and these docs.

--- a/marketing/hackernews/self-host-dry-run.md
+++ b/marketing/hackernews/self-host-dry-run.md
@@ -1,0 +1,59 @@
+# Self-host dry run — pre-launch checklist
+
+Goal: before the Show HN, have 3-5 developers run a self-hosted instance from a clean machine using only the public docs, and fix every doc gap they hit. On launch day, "I tried to self-host and it didn't work" is the most damaging comment; this is the cheapest way to prevent it.
+
+## Recruit
+
+- 3-5 people who have not set up the project before (the unfamiliarity is the point).
+- Mix of OS: at least one macOS (arm64), one Linux x86_64, ideally one Windows (WSL).
+- They should use only the public README + [docs/SELF_HOST.md](../../docs/SELF_HOST.md) — no asking the maintainer in chat. Every question they need to ask is a doc bug.
+
+## Path under test
+
+The path HN visitors will follow first:
+
+```bash
+git clone https://github.com/shrimpsend/shrimpsend.git
+cd shrimpsend
+./scripts/setup-local-config.sh
+docker compose up -d
+cd web && npm ci && npm run dev
+# open http://localhost:3000, sign up, add a second device/browser, send a message
+```
+
+## Tester card (each tester fills one)
+
+```
+Tester:            ______________________
+OS / arch:         ______________________
+Date:              ______________________
+Clone -> running:  ____ minutes
+Got stuck? Where:  ______________________
+Exact error(s):    ______________________
+Doc gap found:     ______________________
+First message sent successfully? (Y/N)
+LAN transfer worked between two devices? (Y/N / not tested)
+Notes:             ______________________
+```
+
+## What to verify
+
+- [ ] `git clone` + `setup-local-config.sh` produces a working `.env` and `config.docker.json` with no manual edits (or the required edits are documented).
+- [ ] `docker compose up -d` brings MySQL, Centrifugo, and backend healthy.
+- [ ] Web client starts and reaches the backend on :9000.
+- [ ] Account creation works on the self-hosted instance.
+- [ ] A second device/browser can join and receive a text message.
+- [ ] (If two physical devices available) LAN direct transfer works.
+- [ ] Total clean-machine time to first message is under ~10 minutes.
+
+## Common failure points to watch
+
+- Ports already in use (3306 / 8000 / 9000 / 3000).
+- MySQL healthcheck timing out on first boot (slow disk / arm64 image pull).
+- Centrifugo image tag mismatch (`docker-compose.yml` pins `centrifugo:v5`; README/docs reference v6 — confirm which the compose path actually needs and align).
+- Missing or placeholder Centrifugo keys causing the backend to reject the WebSocket connection.
+- `npm ci` failing on Node < 20.
+
+## Output
+
+For every gap a tester hits, either fix the doc/script in the same week or file a tracked issue. Re-run the dry run until a fresh tester reaches "first message sent" with zero out-of-band questions. Only then check the "3 testers succeeded" box in the launch-day playbook.

--- a/marketing/hackernews/warmup-comment-bank.md
+++ b/marketing/hackernews/warmup-comment-bank.md
@@ -1,0 +1,42 @@
+# Warm-up comment bank (HN organic participation)
+
+Use in the 2-3 weeks before launch. The goal is to build a small, genuine track record on HN so your account is not brand-new on launch day, and to learn how this audience talks about transfer/NAT/self-hosting topics.
+
+## Rules (do not skip)
+
+- Add real value first. Answer the question or share a concrete insight; mention ShrimpSend only when it is genuinely relevant, and disclose that you built it.
+- Never astroturf: no sock-puppet accounts, no asking friends to upvote, no dropping links with no substance. HN detects and punishes this, and it is unrecoverable.
+- 2-3 substantive comments per week is plenty. Quality over volume.
+- If a thread is not actually about your problem space, do not shoehorn the product in.
+
+## Where to look
+
+Search HN (via Algolia: https://hn.algolia.com) and comment on live threads about:
+
+- LocalSend, Syncthing, Snapdrop/Pairdrop, Magic Wormhole, KDE Connect
+- NAT traversal, hole punching, WebRTC data channels, STUN/TURN
+- Self-hosting file transfer / "send a file between my own devices"
+- Windows firewall / one-way connectivity frustrations
+
+## Disclosure line (reuse)
+
+> Disclosure: I work on ShrimpSend, an open-source tool in this space, so I'm biased.
+
+## Example comments (adapt, never paste verbatim)
+
+### On a NAT/connectivity thread
+> One thing that surprised me building a device-to-device transfer tool: reachability is directional. On the same Wi-Fi, a phone can usually POST to a desktop, but the desktop often can't connect back (Windows firewall, mobile listener restrictions, or the AP isolating clients). Retrying the same direction just times out. Flipping it — let the reachable side pull instead of insisting the sender push — recovers a surprising fraction of "same network but won't connect" cases before you even reach for WebRTC. (Disclosure: I work on a tool that does this.)
+
+### On a LocalSend / LAN-transfer thread
+> LocalSend is great when every device is on a reachable LAN with the app installed. The cases it doesn't target are cross-network sends, one-way firewalls, resume after a drop, and joining from a browser on a machine where you can't install anything. Those are exactly the gaps that pushed me to build something with a server-coordinated fallback chain. Different tradeoff — more moving parts, but it keeps working off the happy path. (Disclosure: biased, I build one of these.)
+
+### On a self-hosting thread
+> If you self-host this kind of thing, the detail that bit me was Centrifugo/WebSocket auth config — easy to get a backend up and then spend an hour on why the realtime channel won't connect. Worth documenting the required env vars with a startup validation check. Happy to share what we ended up with.
+
+## Track it
+
+Keep a short log so you do not over-post or repeat yourself:
+
+```
+Date | Thread (url) | Topic | Linked product? (Y/N) | Notes
+```

--- a/shared/protocol.en.md
+++ b/shared/protocol.en.md
@@ -1,0 +1,64 @@
+# ShrimpSend Transfer Protocol (English summary)
+
+This is a condensed English overview of the ShrimpSend / 虾传 transfer protocol for readers who do not read Chinese. The full, authoritative specification lives in [shared/protocol.md](protocol.md); when the two disagree, the Chinese document wins.
+
+ShrimpSend moves data between a user's own devices. It picks the best available path at send time and degrades gracefully when the network is hostile, rather than failing the transfer. The paths, in order of preference, are: HTTP direct push on the LAN, HTTP reverse pull, WebRTC peer-to-peer, and S3-compatible relay.
+
+## Why a multi-path protocol
+
+"Same network" does not guarantee two devices can reach each other. A Windows firewall commonly blocks inbound connections, so a phone can push to a PC while the PC cannot push back. Devices may sit on different subnets (Ethernet vs. Wi-Fi, or behind a secondary router) even at home. Hotel, campus, and carrier networks add NAT and restrictive firewalls. ShrimpSend treats one-way reachability as the normal case and is built to work around it.
+
+```mermaid
+flowchart TD
+  start[Send request] --> probeA{Receiver reachable<br/>for direct push?}
+  probeA -->|yes| push[HTTP direct push on LAN]
+  probeA -->|no| probeB{Sender reachable<br/>for reverse pull?}
+  probeB -->|yes| pull[HTTP reverse pull]
+  probeB -->|no| webrtc{WebRTC P2P<br/>established?}
+  webrtc -->|yes| p2p[WebRTC DataChannel]
+  webrtc -->|no| relay[S3-compatible relay]
+```
+
+## HTTP direct push (LAN)
+
+The sender posts the file body directly to the receiver:
+
+- `POST /transfer` with headers `X-File-Name`, `X-File-Size`, and `Content-Type: application/octet-stream`.
+- Resume is supported with optional `X-File-Id` and `X-Resume-Offset` headers; the body starts at the requested offset.
+- `GET /probe` returns `200 OK` and is used for reachability checks.
+- `GET /transfer-status?fileId=...` returns an `X-Received-Bytes` header so the sender can learn how much has already landed. `fileId` is derived from `hash(fileName)_fileSize`.
+
+## Reverse pull
+
+When direct push fails because the receiver cannot accept inbound connections, the protocol flips direction: the reachable side exposes the file and the other side pulls it.
+
+- `GET /download?offerId=...` serves the file.
+- `Range: bytes=start-` requests are honored and answered with `206 Partial Content` and a `Content-Range` header, so an interrupted pull resumes instead of restarting.
+
+After sign-in, the server coordinates reachability probes between the two devices and decides whether to push or pull, so this is automatic rather than a manual user choice.
+
+## WebRTC peer-to-peer
+
+When neither HTTP path works directly but a peer connection can still be negotiated, ShrimpSend uses WebRTC.
+
+- Signaling messages travel over Centrifugo: `webrtc_offer`, `webrtc_answer`, `webrtc_ice_candidate`, and `webrtc_transfer_cancel`.
+- A `control` DataChannel carries JSON control messages; each file gets its own `file-{fileId}` DataChannel transferred in 16 KB chunks.
+- Control messages cover the full lifecycle: `file_start`, `file_end`, `file_ack`, `progress` (for end-to-end flow control), `file_resume_request` / `file_resume_accept` (for resume), and `session_complete`.
+- Resume flow: the receiver checks for a partially received temp file after `file_start`, sends `file_resume_request` with the bytes it already has, and the sender replies `file_resume_accept` with the offset to continue from. The receiver flushes partial data to a temp file roughly every 2 MB.
+
+## S3-compatible relay (fallback)
+
+S3 is a fallback path, not a replacement for LAN transfer. It keeps delivery reliable when devices are on different networks or the network is constrained. Storage can be the hosted bucket or a user-supplied S3-compatible endpoint.
+
+- Small files (< 5 MB): `POST /api/s3/presign-upload` returns a presigned PUT URL; download via `GET /api/s3/download-url?key=...`.
+- Large files (>= 5 MB) use multipart upload with resume: `POST /api/s3/multipart/initiate`, `POST /api/s3/multipart/presign-part` per part, `PUT` each part to its presigned URL, then `POST /api/s3/multipart/complete` (or `.../abort`). Download resume uses the HTTP `Range` header.
+
+## Integrity
+
+- The sender computes a SHA-256 hash before upload and sends it via `X-File-Hash` on LAN paths.
+- For S3, ETag can be used for verification.
+- After a transfer completes, the receiver can verify the hash matches.
+
+## Real-time sync
+
+Centrifugo pushes updates to every signed-in client on the channel `user#<userId>`, which is also how WebRTC signaling and device/conversation state propagate across a user's devices in real time.


### PR DESCRIPTION
- README 增加 5 分钟 Docker 上手段落与英文协议链接
- 新增 shared/protocol.en.md 英文协议摘要
- 新增 .github Issue/PR 模板与 RELEASE_NOTES 草稿
- 新增 marketing/hackernews 全套发帖资产（首评、FAQ、playbook 等）