### PR TITLE
Cursor/webdav membership gate

### DIFF
--- a/app/lib/api/membership.dart
+++ b/app/lib/api/membership.dart
@@ -44,6 +44,7 @@ class MembershipMe {
   final int addonPacks;
   final int currentDeviceCount;
   final bool canAddDevice;
+  final bool canAddWebDav;
   final bool canBuyAddon;
   final int? subscriptionExpiresAtMs;
   final bool? subscriptionCancelAtPeriodEnd;
@@ -65,6 +66,7 @@ class MembershipMe {
     this.addonPacks = 0,
     required this.currentDeviceCount,
     required this.canAddDevice,
+    this.canAddWebDav = false,
     this.canBuyAddon = false,
     this.subscriptionExpiresAtMs,
     this.subscriptionCancelAtPeriodEnd,
@@ -85,6 +87,7 @@ class MembershipMe {
       addonPacks: (j['addonPacks'] as num?)?.toInt() ?? 0,
       currentDeviceCount: (j['currentDeviceCount'] as num?)?.toInt() ?? 0,
       canAddDevice: j['canAddDevice'] == true,
+      canAddWebDav: j['canAddWebDav'] == true,
       canBuyAddon: j['canBuyAddon'] == true,
       subscriptionExpiresAtMs: (j['subscriptionExpiresAtMs'] as num?)?.toInt(),
       subscriptionCancelAtPeriodEnd: j['subscriptionCancelAtPeriodEnd'] as bool?,

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -101,6 +101,7 @@
   "settingsNavS3Subtitle": "Wide-area file transfer",
   "settingsNavWebDav": "WebDAV",
   "settingsNavWebDavSubtitle": "Remote file storage",
+  "settingsWebDavMemberOnly": "Members only",
   "settingsWebDavStatusNone": "Not configured",
   "settingsWebDavStatusCount": "{count, plural, =1{1 connection} other{{count} connections}}",
   "@settingsWebDavStatusCount": {
@@ -1043,6 +1044,7 @@
       }
     }
   },
+  "membershipFeatureWebDav": "WebDAV remote storage (unlimited connections)",
   "membershipPlanPopular": "Popular",
   "membershipOverseasNoAlipay": "Overseas builds don’t support Alipay — subscribe in the app.",
   "membershipSubscribeInApp": "Subscribe in app",
@@ -1798,6 +1800,10 @@
   "webdavAddMenuTooltip": "Add connection",
   "webdavScanLogin": "Scan to sign in",
   "webdavAddConnection": "Add WebDAV",
+  "webdavMemberOnlyTitle": "WebDAV is a member feature",
+  "webdavMemberOnlyBody": "Subscribe to add WebDAV connections with no limit. Existing connections keep working.",
+  "webdavMemberOnlyAction": "Upgrade membership",
+  "webdavEmptyMemberPrompt": "WebDAV is a member feature. Upgrade to add remote storage connections with no limit.",
   "webdavEditConnection": "Edit WebDAV",
   "webdavSectionTitle": "WebDAV",
   "webdavFormName": "Name",

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -81,6 +81,7 @@
   "settingsNavS3Subtitle": "广域网文件传输",
   "settingsNavWebDav": "WebDAV",
   "settingsNavWebDavSubtitle": "远程文件存储",
+  "settingsWebDavMemberOnly": "会员功能",
   "settingsWebDavStatusNone": "未配置",
   "settingsWebDavStatusCount": "{count} 个连接",
   "@settingsWebDavStatusCount": {
@@ -684,6 +685,7 @@
       }
     }
   },
+  "membershipFeatureWebDav": "WebDAV 远程存储（不限连接数）",
   "membershipPlanPopular": "推荐",
   "membershipOverseasNoAlipay": "海外版不支持支付宝，请使用应用内订阅完成支付。",
   "membershipSubscribeInApp": "应用内订阅",
@@ -1345,6 +1347,10 @@
   "webdavAddMenuTooltip": "添加连接",
   "webdavScanLogin": "扫码登录",
   "webdavAddConnection": "添加 WebDAV",
+  "webdavMemberOnlyTitle": "WebDAV 为会员功能",
+  "webdavMemberOnlyBody": "开通会员后即可添加 WebDAV 连接，数量不限。已有连接可继续正常使用。",
+  "webdavMemberOnlyAction": "去开通会员",
+  "webdavEmptyMemberPrompt": "WebDAV 为会员功能。开通会员后可添加远程存储连接，数量不限。",
   "webdavEditConnection": "编辑 WebDAV",
   "webdavSectionTitle": "WebDAV",
   "webdavFormName": "名称",

--- a/app/lib/l10n/generated/app_localizations.dart
+++ b/app/lib/l10n/generated/app_localizations.dart
@@ -542,6 +542,12 @@ abstract class AppLocalizations {
   /// **'Remote file storage'**
   String get settingsNavWebDavSubtitle;
 
+  /// No description provided for @settingsWebDavMemberOnly.
+  ///
+  /// In en, this message translates to:
+  /// **'Members only'**
+  String get settingsWebDavMemberOnly;
+
   /// No description provided for @settingsWebDavStatusNone.
   ///
   /// In en, this message translates to:
@@ -3426,6 +3432,12 @@ abstract class AppLocalizations {
   /// **'{gib} GiB / month hosted upload quota'**
   String membershipFeatureUploadHosted(int gib);
 
+  /// No description provided for @membershipFeatureWebDav.
+  ///
+  /// In en, this message translates to:
+  /// **'WebDAV remote storage (unlimited connections)'**
+  String get membershipFeatureWebDav;
+
   /// No description provided for @membershipPlanPopular.
   ///
   /// In en, this message translates to:
@@ -5609,6 +5621,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Add WebDAV'**
   String get webdavAddConnection;
+
+  /// No description provided for @webdavMemberOnlyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'WebDAV is a member feature'**
+  String get webdavMemberOnlyTitle;
+
+  /// No description provided for @webdavMemberOnlyBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Subscribe to add WebDAV connections with no limit. Existing connections keep working.'**
+  String get webdavMemberOnlyBody;
+
+  /// No description provided for @webdavMemberOnlyAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Upgrade membership'**
+  String get webdavMemberOnlyAction;
+
+  /// No description provided for @webdavEmptyMemberPrompt.
+  ///
+  /// In en, this message translates to:
+  /// **'WebDAV is a member feature. Upgrade to add remote storage connections with no limit.'**
+  String get webdavEmptyMemberPrompt;
 
   /// No description provided for @webdavEditConnection.
   ///

--- a/app/lib/l10n/generated/app_localizations_en.dart
+++ b/app/lib/l10n/generated/app_localizations_en.dart
@@ -247,6 +247,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsNavWebDavSubtitle => 'Remote file storage';
 
   @override
+  String get settingsWebDavMemberOnly => 'Members only';
+
+  @override
   String get settingsWebDavStatusNone => 'Not configured';
 
   @override
@@ -1892,6 +1895,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get membershipFeatureWebDav =>
+      'WebDAV remote storage (unlimited connections)';
+
+  @override
   String get membershipPlanPopular => 'Popular';
 
   @override
@@ -3177,6 +3184,20 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get webdavAddConnection => 'Add WebDAV';
+
+  @override
+  String get webdavMemberOnlyTitle => 'WebDAV is a member feature';
+
+  @override
+  String get webdavMemberOnlyBody =>
+      'Subscribe to add WebDAV connections with no limit. Existing connections keep working.';
+
+  @override
+  String get webdavMemberOnlyAction => 'Upgrade membership';
+
+  @override
+  String get webdavEmptyMemberPrompt =>
+      'WebDAV is a member feature. Upgrade to add remote storage connections with no limit.';
 
   @override
   String get webdavEditConnection => 'Edit WebDAV';

--- a/app/lib/l10n/generated/app_localizations_zh.dart
+++ b/app/lib/l10n/generated/app_localizations_zh.dart
@@ -239,6 +239,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settingsNavWebDavSubtitle => '远程文件存储';
 
   @override
+  String get settingsWebDavMemberOnly => '会员功能';
+
+  @override
   String get settingsWebDavStatusNone => '未配置';
 
   @override
@@ -1821,6 +1824,9 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get membershipFeatureWebDav => 'WebDAV 远程存储（不限连接数）';
+
+  @override
   String get membershipPlanPopular => '推荐';
 
   @override
@@ -3031,6 +3037,18 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get webdavAddConnection => '添加 WebDAV';
+
+  @override
+  String get webdavMemberOnlyTitle => 'WebDAV 为会员功能';
+
+  @override
+  String get webdavMemberOnlyBody => '开通会员后即可添加 WebDAV 连接，数量不限。已有连接可继续正常使用。';
+
+  @override
+  String get webdavMemberOnlyAction => '去开通会员';
+
+  @override
+  String get webdavEmptyMemberPrompt => 'WebDAV 为会员功能。开通会员后可添加远程存储连接，数量不限。';
 
   @override
   String get webdavEditConnection => '编辑 WebDAV';

--- a/app/lib/screens/chat_screen.dart
+++ b/app/lib/screens/chat_screen.dart
@@ -39,6 +39,7 @@ import '../utils/helpers.dart';
 import '../utils/open_received_file.dart';
 import '../utils/received_file_actions.dart';
 import '../utils/save_as_feedback.dart';
+import '../utils/webdav_membership_gate.dart';
 import '../utils/reveal_file_in_folder.dart';
 import '../utils/toast.dart';
 import '../widgets/app_confirm_dialog.dart';
@@ -8820,6 +8821,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
       await Navigator.pushNamed(context, '/login');
       return;
     }
+    if (!await ensureCanAddWebDav(context)) return;
+    if (!mounted) return;
     final ok = await Navigator.push<bool>(
       context,
       MaterialPageRoute(

--- a/app/lib/screens/membership_screen.dart
+++ b/app/lib/screens/membership_screen.dart
@@ -824,6 +824,11 @@ class _MembershipScreenState extends ConsumerState<MembershipScreen> {
                     colors,
                     l10n.membershipFeatureUploadHosted(uploadGib),
                   ),
+                  _bulletLine(
+                    theme,
+                    colors,
+                    l10n.membershipFeatureWebDav,
+                  ),
                   const SizedBox(height: AppSpacing.md),
                   if (disabled && !(_pendingOrderNo != null || _purchasingApple))
                     Padding(
@@ -1238,6 +1243,15 @@ class _MembershipScreenState extends ConsumerState<MembershipScreen> {
                                             : l10n.membershipTierSubtitleBuyout),
                                     style: theme.textTheme.bodySmall?.copyWith(color: colors.textSecondary),
                                   ),
+                                  if (!isAddon) ...[
+                                    const SizedBox(height: AppSpacing.xs),
+                                    Text(
+                                      l10n.membershipFeatureWebDav,
+                                      style: theme.textTheme.bodySmall?.copyWith(
+                                        color: colors.textSecondary,
+                                      ),
+                                    ),
+                                  ],
                                   const SizedBox(height: AppSpacing.sm),
                                   if (isAddon && !canBuyAddon) ...[
                                     Text(

--- a/app/lib/screens/settings_screen.dart
+++ b/app/lib/screens/settings_screen.dart
@@ -31,9 +31,9 @@ import '../providers/webdav_provider.dart';
 import '../theme_store.dart';
 import '../ui/app_ui.dart';
 import '../utils/effective_save_dir_display.dart';
-import '../utils/effective_save_dir_display.dart';
 import '../utils/gallery_permission.dart';
 import '../utils/toast.dart';
+import '../utils/webdav_membership_gate.dart';
 import '../widgets/app_confirm_dialog.dart';
 import '../services/app_update_service.dart';
 import '../services/analytics/analytics.dart';
@@ -472,7 +472,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                                     .withValues(alpha: 0.12),
                                 iconColor: theme.colorScheme.primary,
                                 title: l10n.settingsNavWebDav,
-                                subtitle: l10n.settingsNavWebDavSubtitle,
+                                subtitle: _webDavNavSubtitle(l10n, ref),
                                 trailing: _buildWebDavStatusBadge(context, ref),
                                 onTap: () async {
                                   await Navigator.pushNamed(
@@ -1152,20 +1152,35 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     );
   }
 
+  String _webDavNavSubtitle(AppLocalizations l10n, WidgetRef ref) {
+    final count = ref.watch(webDavConnectionsProvider).valueOrNull?.length ?? 0;
+    if (count == 0 && !membershipCanAddWebDav(_membership)) {
+      return l10n.settingsWebDavMemberOnly;
+    }
+    return l10n.settingsNavWebDavSubtitle;
+  }
+
   Widget _buildWebDavStatusBadge(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final colors = context.appColors;
     final l10n = AppLocalizations.of(context);
     final webDavAsync = ref.watch(webDavConnectionsProvider);
     final count = webDavAsync.valueOrNull?.length ?? 0;
+    final canAddWebDav = membershipCanAddWebDav(_membership);
 
     final Color background;
     final Color foreground;
     final String label;
     if (count == 0) {
-      background = colors.surfaceMuted;
-      foreground = colors.textSecondary;
-      label = l10n.settingsWebDavStatusNone;
+      if (!canAddWebDav) {
+        background = colors.surfaceMuted;
+        foreground = colors.textSecondary;
+        label = l10n.settingsWebDavMemberOnly;
+      } else {
+        background = colors.surfaceMuted;
+        foreground = colors.textSecondary;
+        label = l10n.settingsWebDavStatusNone;
+      }
     } else {
       final scheme = theme.colorScheme;
       background = scheme.primary.withValues(alpha: 0.12);

--- a/app/lib/screens/webdav_connection_screen.dart
+++ b/app/lib/screens/webdav_connection_screen.dart
@@ -9,6 +9,7 @@ import '../services/webdav_credential_store.dart';
 import '../ui/app_ui.dart';
 import '../utils/auth_route_guard.dart';
 import '../utils/toast.dart';
+import '../utils/webdav_membership_gate.dart';
 
 class WebDavConnectionScreen extends ConsumerStatefulWidget {
   final int? connectionId;
@@ -117,6 +118,8 @@ class _WebDavConnectionScreenState extends ConsumerState<WebDavConnectionScreen>
       AppToast.show(context, message: AppLocalizations.of(context).webdavPasswordRequired);
       return;
     }
+    if (!_isEdit && !await ensureCanAddWebDav(context)) return;
+    if (!mounted) return;
     setState(() => _testing = true);
     final l10n = AppLocalizations.of(context);
     try {
@@ -142,6 +145,8 @@ class _WebDavConnectionScreenState extends ConsumerState<WebDavConnectionScreen>
       AppToast.show(context, message: AppLocalizations.of(context).webdavPasswordRequired);
       return;
     }
+    if (!_isEdit && !await ensureCanAddWebDav(context)) return;
+    if (!mounted) return;
     setState(() => _saving = true);
     final l10n = AppLocalizations.of(context);
     try {

--- a/app/lib/screens/webdav_settings_screen.dart
+++ b/app/lib/screens/webdav_settings_screen.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
+import '../api/membership.dart';
 import '../l10n/generated/app_localizations.dart';
 import '../providers/webdav_provider.dart';
 import '../screens/webdav_connection_screen.dart';
 import '../ui/app_ui.dart';
 import '../utils/auth_route_guard.dart';
+import '../utils/webdav_membership_gate.dart';
 import '../widgets/webdav/webdav_connection_actions.dart';
 import '../widgets/webdav/webdav_connection_item.dart';
 
@@ -19,6 +21,8 @@ class WebDavSettingsScreen extends ConsumerStatefulWidget {
 }
 
 class _WebDavSettingsScreenState extends ConsumerState<WebDavSettingsScreen> {
+  MembershipMe? _membership;
+
   @override
   void initState() {
     super.initState();
@@ -26,10 +30,20 @@ class _WebDavSettingsScreenState extends ConsumerState<WebDavSettingsScreen> {
       if (!mounted) return;
       if (!ensureLoggedInForRoute(context, ref)) return;
       ref.read(webDavConnectionsProvider.notifier).refresh();
+      _loadMembership();
     });
   }
 
+  Future<void> _loadMembership() async {
+    try {
+      final me = await fetchMyMembership();
+      if (mounted) setState(() => _membership = me);
+    } catch (_) {}
+  }
+
   Future<void> _openAddConnection() async {
+    if (!await ensureCanAddWebDav(context, membership: _membership)) return;
+    if (!mounted) return;
     final ok = await Navigator.push<bool>(
       context,
       MaterialPageRoute(builder: (_) => const WebDavConnectionScreen()),
@@ -37,6 +51,11 @@ class _WebDavSettingsScreenState extends ConsumerState<WebDavSettingsScreen> {
     if (ok == true && mounted) {
       await ref.read(webDavConnectionsProvider.notifier).refresh();
     }
+  }
+
+  Future<void> _openMembership() async {
+    await Navigator.pushNamed(context, '/settings/membership');
+    if (mounted) await _loadMembership();
   }
 
   Future<void> _openEditConnection(int connectionId) async {
@@ -58,6 +77,7 @@ class _WebDavSettingsScreenState extends ConsumerState<WebDavSettingsScreen> {
     final colors = context.appColors;
     final webDavAsync = ref.watch(webDavConnectionsProvider);
     final connections = webDavAsync.valueOrNull ?? const [];
+    final canAddWebDav = membershipCanAddWebDav(_membership);
 
     return Scaffold(
       appBar: AppBar(
@@ -110,18 +130,27 @@ class _WebDavSettingsScreenState extends ConsumerState<WebDavSettingsScreen> {
                     ),
                     const SizedBox(height: AppSpacing.md),
                     Text(
-                      l10n.settingsWebDavListEmpty,
+                      canAddWebDav
+                          ? l10n.settingsWebDavListEmpty
+                          : l10n.webdavEmptyMemberPrompt,
                       style: theme.textTheme.bodyMedium?.copyWith(
                         color: colors.textSecondary,
                       ),
                       textAlign: TextAlign.center,
                     ),
                     const SizedBox(height: AppSpacing.lg),
-                    FilledButton.icon(
-                      onPressed: _openAddConnection,
-                      icon: const Icon(LucideIcons.plus, size: 18),
-                      label: Text(l10n.webdavAddConnection),
-                    ),
+                    if (canAddWebDav)
+                      FilledButton.icon(
+                        onPressed: _openAddConnection,
+                        icon: const Icon(LucideIcons.plus, size: 18),
+                        label: Text(l10n.webdavAddConnection),
+                      )
+                    else
+                      FilledButton.icon(
+                        onPressed: _openMembership,
+                        icon: const Icon(LucideIcons.crown, size: 18),
+                        label: Text(l10n.webdavMemberOnlyAction),
+                      ),
                   ],
                 ),
               ),
@@ -129,8 +158,10 @@ class _WebDavSettingsScreenState extends ConsumerState<WebDavSettingsScreen> {
           }
 
           return RefreshIndicator(
-            onRefresh: () =>
-                ref.read(webDavConnectionsProvider.notifier).refresh(),
+            onRefresh: () async {
+              await ref.read(webDavConnectionsProvider.notifier).refresh();
+              await _loadMembership();
+            },
             child: ListView.builder(
               padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
               itemCount: items.length,

--- a/app/lib/screens/webdav_settings_tab.dart
+++ b/app/lib/screens/webdav_settings_tab.dart
@@ -6,6 +6,7 @@ import '../api/webdav.dart';
 import '../l10n/generated/app_localizations.dart';
 import '../providers/webdav_provider.dart';
 import '../ui/app_ui.dart';
+import '../utils/webdav_membership_gate.dart';
 import 'webdav_connection_screen.dart';
 import 'webdav_transfer_list_screen.dart';
 
@@ -99,6 +100,8 @@ class WebDavSettingsTab extends ConsumerWidget {
           title: Text(l10n.webdavAddConnection),
           trailing: const Icon(LucideIcons.chevronRight, size: 18),
           onTap: () async {
+            if (!await ensureCanAddWebDav(context)) return;
+            if (!context.mounted) return;
             await Navigator.push(
               context,
               MaterialPageRoute(

--- a/app/lib/utils/webdav_membership_gate.dart
+++ b/app/lib/utils/webdav_membership_gate.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+import '../api/membership.dart';
+import '../l10n/generated/app_localizations.dart';
+
+/// Returns whether the user may add new WebDAV connections.
+bool membershipCanAddWebDav(MembershipMe? me) => me?.canAddWebDav ?? false;
+
+/// Ensures the user may add WebDAV. Shows upgrade dialog when not allowed.
+/// Returns `true` if the caller should proceed (e.g. open add form).
+Future<bool> ensureCanAddWebDav(
+  BuildContext context, {
+  MembershipMe? membership,
+}) async {
+  MembershipMe? me = membership;
+  if (me == null) {
+    try {
+      me = await fetchMyMembership();
+    } catch (_) {
+      me = null;
+    }
+  }
+  if (membershipCanAddWebDav(me)) return true;
+  if (!context.mounted) return false;
+
+  final l10n = AppLocalizations.of(context);
+  final upgrade = await showDialog<bool>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: Text(l10n.webdavMemberOnlyTitle),
+      content: Text(l10n.webdavMemberOnlyBody),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(ctx, false),
+          child: Text(l10n.cancel),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(ctx, true),
+          child: Text(l10n.webdavMemberOnlyAction),
+        ),
+      ],
+    ),
+  );
+  if (upgrade == true && context.mounted) {
+    await Navigator.pushNamed(context, '/settings/membership');
+  }
+  return false;
+}

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,8 +26,11 @@ APP_USER_DATA_ENCRYPTION_MIGRATE_USER_DEK_ON_STARTUP=false
 APP_ADMIN_EMAILS=admin@example.com
 # 生产环境也可在 ops application-prod*.yml 的 app.admin.emails 中配置（与 web NEXT_PUBLIC_ADMIN_EMAILS 保持一致）
 
+# SendCloud 触发类 API_USER（发送设置中获取）；from 须为已验证发件地址
 SENDCLOUD_API_USER=
 SENDCLOUD_API_KEY=
+SENDCLOUD_FROM=
+SENDCLOUD_FROM_NAME=虾传
 
 TENCENT_SMS_SECRET_ID=
 TENCENT_SMS_SECRET_KEY=

--- a/backend/src/main/java/dev/ultrasend/backend/controller/WebDavController.java
+++ b/backend/src/main/java/dev/ultrasend/backend/controller/WebDavController.java
@@ -83,6 +83,6 @@ public class WebDavController {
             @Valid @RequestBody WebDavConnectionRequest req) {
         Long userId = Long.parseLong((String) auth.getPrincipal());
         log.info("webdav testDraft userId={}", userId);
-        return ResponseEntity.ok(webDavConnectionService.testDraft(req));
+        return ResponseEntity.ok(webDavConnectionService.testDraft(userId, req));
     }
 }

--- a/backend/src/main/java/dev/ultrasend/backend/dto/MembershipMeResponse.java
+++ b/backend/src/main/java/dev/ultrasend/backend/dto/MembershipMeResponse.java
@@ -16,6 +16,8 @@ public class MembershipMeResponse {
     private Integer addonPacks;
     private Integer currentDeviceCount;
     private Boolean canAddDevice;
+    /** {@code true} if the user may create new WebDAV connections (paid tier). */
+    private Boolean canAddWebDav;
     private Boolean canBuyAddon;
     /** Overseas subscription period end (epoch millis). */
     private Long subscriptionExpiresAtMs;

--- a/backend/src/main/java/dev/ultrasend/backend/service/MembershipService.java
+++ b/backend/src/main/java/dev/ultrasend/backend/service/MembershipService.java
@@ -76,6 +76,9 @@ public class MembershipService {
 
     public static final String ADDON_PRODUCT_CODE = "ADDON_5";
 
+    public static final String WEBDAV_MEMBER_ONLY_MESSAGE =
+            "WebDAV 为会员功能，请开通会员后再添加连接";
+
     public List<MembershipTierDto> listTiers() {
         if (clusterDeploymentService.isOverseasDeployment()) {
             return listOverseasTiers();
@@ -132,6 +135,7 @@ public class MembershipService {
                 paymentChannel = "FREE";
             }
             boolean canSwitch = "FREE".equals(paymentChannel);
+            boolean canAddWebDav = canAddWebDav(userId);
             return MembershipMeResponse.builder()
                     .tierCode(ot.getCode())
                     .tierName(ot.getDisplayName())
@@ -139,6 +143,7 @@ public class MembershipService {
                     .addonPacks(0)
                     .currentDeviceCount(currentCount)
                     .canAddDevice(currentCount < limit)
+                    .canAddWebDav(canAddWebDav)
                     .canBuyAddon(false)
                     .subscriptionExpiresAtMs(expMs)
                     .subscriptionCancelAtPeriodEnd(cancelAtEnd)
@@ -158,6 +163,7 @@ public class MembershipService {
                 .map(e -> e.getAddonPacks() != null ? e.getAddonPacks() : 0)
                 .orElse(0);
         boolean canBuyAddon = tier == MembershipTier.MINI || tier == MembershipTier.PRO;
+        boolean canAddWebDav = canAddWebDav(userId);
         String paymentChannel = entOpt.map(MembershipEntitlement::getPaymentChannel).orElse("FREE");
         if (paymentChannel == null || paymentChannel.isBlank()) {
             paymentChannel = tier == MembershipTier.FREE ? "FREE" : "ALIPAY_LIFETIME";
@@ -169,6 +175,7 @@ public class MembershipService {
                 .addonPacks(addonPacks)
                 .currentDeviceCount(currentCount)
                 .canAddDevice(currentCount < limit)
+                .canAddWebDav(canAddWebDav)
                 .canBuyAddon(canBuyAddon)
                 .paymentChannel(paymentChannel)
                 .canSwitchChannel("FREE".equals(paymentChannel))
@@ -239,6 +246,19 @@ public class MembershipService {
         return membershipEntitlementRepository.findByUserId(userId)
                 .map(entitlement -> MembershipTier.fromCode(entitlement.getTierCode()))
                 .orElse(MembershipTier.FREE);
+    }
+
+    public boolean canAddWebDav(Long userId) {
+        if (clusterDeploymentService.isOverseasDeployment()) {
+            return hostedQuotaService.effectiveTier(userId) != OverseasMembershipTier.FREE;
+        }
+        return getCurrentTier(userId) != MembershipTier.FREE;
+    }
+
+    public void ensureCanAddWebDav(Long userId) {
+        if (!canAddWebDav(userId)) {
+            throw new IllegalArgumentException(WEBDAV_MEMBER_ONLY_MESSAGE);
+        }
     }
 
     public int resolveDeviceLimitForUser(Long userId) {

--- a/backend/src/main/java/dev/ultrasend/backend/service/SendCloudMailService.java
+++ b/backend/src/main/java/dev/ultrasend/backend/service/SendCloudMailService.java
@@ -1,6 +1,9 @@
 package dev.ultrasend.backend.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -8,8 +11,6 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
-
-import java.util.Map;
 
 @Service
 @Slf4j
@@ -22,17 +23,37 @@ public class SendCloudMailService {
     private final String from;
     private final String fromName;
     private final WebClient webClient;
+    private final ObjectMapper objectMapper;
 
+    @Autowired
     public SendCloudMailService(
             @Value("${sendcloud.api-user}") String apiUser,
             @Value("${sendcloud.api-key}") String apiKey,
             @Value("${sendcloud.from}") String from,
-            @Value("${sendcloud.from-name:虾传}") String fromName) {
+            @Value("${sendcloud.from-name:虾传}") String fromName,
+            ObjectMapper objectMapper) {
+        this(apiUser, apiKey, from, fromName, WebClient.create(), objectMapper);
+    }
+
+    SendCloudMailService(
+            String apiUser,
+            String apiKey,
+            String from,
+            String fromName,
+            WebClient webClient,
+            ObjectMapper objectMapper) {
         this.apiUser = apiUser;
         this.apiKey = apiKey;
         this.from = from;
         this.fromName = fromName;
-        this.webClient = WebClient.create();
+        this.webClient = webClient;
+        this.objectMapper = objectMapper;
+
+        if (isConfigured()) {
+            log.info("sendcloud mail service initialized: apiUser={} from={}", apiUser, from);
+        } else {
+            log.warn("sendcloud mail service initialized but credentials are missing");
+        }
     }
 
     public void sendVerificationCode(String to, String code) {
@@ -42,6 +63,8 @@ public class SendCloudMailService {
     }
 
     private void sendMail(String to, String subject, String html) {
+        assertConfigured();
+
         MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
         formData.add("apiUser", apiUser);
         formData.add("apiKey", apiKey);
@@ -59,10 +82,43 @@ public class SendCloudMailService {
                     .retrieve()
                     .bodyToMono(String.class)
                     .block();
-            log.info("sendcloud mail sent to={} response={}", to, response);
+            validateResponse(response, to);
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
-            log.error("sendcloud mail failed to={}", to, e);
+            log.error("sendcloud mail request failed to={}", to, e);
             throw new RuntimeException("邮件发送失败，请稍后重试");
+        }
+    }
+
+    void validateResponse(String response, String to) {
+        try {
+            JsonNode root = objectMapper.readTree(response);
+            if (root.path("result").asBoolean(false)) {
+                log.info("sendcloud mail success to={} response={}", to, response);
+                return;
+            }
+            int statusCode = root.path("statusCode").asInt(-1);
+            String message = root.path("message").asText("未知错误");
+            log.error("sendcloud mail failed to={} statusCode={} message={} response={}",
+                    to, statusCode, message, response);
+            throw new RuntimeException("邮件发送失败：" + message + " (code: " + statusCode + ")");
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("sendcloud mail response parse failed to={} response={}", to, response, e);
+            throw new RuntimeException("邮件发送失败，请稍后重试");
+        }
+    }
+
+    private boolean isConfigured() {
+        return apiUser != null && !apiUser.isBlank()
+                && apiKey != null && !apiKey.isBlank();
+    }
+
+    private void assertConfigured() {
+        if (!isConfigured()) {
+            throw new RuntimeException("邮件服务未配置，请联系管理员");
         }
     }
 

--- a/backend/src/main/java/dev/ultrasend/backend/service/WebDavConnectionService.java
+++ b/backend/src/main/java/dev/ultrasend/backend/service/WebDavConnectionService.java
@@ -23,6 +23,7 @@ public class WebDavConnectionService {
     private final WebDavConnectionRepository webDavConnectionRepository;
     private final UserRepository userRepository;
     private final UserDataEncryptionService userDataEncryption;
+    private final MembershipService membershipService;
 
     public List<WebDavConnectionSummaryResponse> listConnections(Long userId) {
         return webDavConnectionRepository.findByUserIdOrderBySortOrderAscIdAsc(userId).stream()
@@ -49,6 +50,7 @@ public class WebDavConnectionService {
 
     @Transactional
     public WebDavConnectionSummaryResponse create(Long userId, WebDavConnectionRequest req) {
+        membershipService.ensureCanAddWebDav(userId);
         validateRequest(req, true);
         User user = userRepository.findById(userId).orElseThrow();
         String baseUrl = WebDavPropfindClient.normalizeBaseUrl(req.getBaseUrl());
@@ -123,7 +125,8 @@ public class WebDavConnectionService {
                 conn.getClientApp());
     }
 
-    public WebDavTestResponse testDraft(WebDavConnectionRequest req) {
+    public WebDavTestResponse testDraft(Long userId, WebDavConnectionRequest req) {
+        membershipService.ensureCanAddWebDav(userId);
         validateRequest(req, true);
         String baseUrl = WebDavPropfindClient.normalizeBaseUrl(req.getBaseUrl());
         CstCloudClientAppSupport.validateWebDavClientApp(baseUrl, req.getClientApp());

--- a/backend/src/test/java/dev/ultrasend/backend/service/SendCloudMailServiceTest.java
+++ b/backend/src/test/java/dev/ultrasend/backend/service/SendCloudMailServiceTest.java
@@ -1,0 +1,67 @@
+package dev.ultrasend.backend.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SendCloudMailServiceTest {
+
+    private SendCloudMailService service;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        service = new SendCloudMailService(
+                "trigger_user",
+                "secret_key",
+                "noreply@example.com",
+                "虾传",
+                WebClient.create(),
+                objectMapper);
+    }
+
+    @Test
+    void validateResponse_acceptsSuccessResult() {
+        String response = """
+                {"result":true,"statusCode":200,"message":"请求成功","info":{}}
+                """;
+
+        assertDoesNotThrow(() -> service.validateResponse(response, "user@example.com"));
+    }
+
+    @Test
+    void validateResponse_rejectsAuthFailure() {
+        String response = """
+                {"result":false,"statusCode":40005,"message":"认证失败","info":{}}
+                """;
+
+        RuntimeException ex = assertThrows(
+                RuntimeException.class,
+                () -> service.validateResponse(response, "user@example.com"));
+
+        assertEquals("邮件发送失败：认证失败 (code: 40005)", ex.getMessage());
+    }
+
+    @Test
+    void sendVerificationCode_rejectsMissingCredentials() {
+        SendCloudMailService unconfigured = new SendCloudMailService(
+                "",
+                "",
+                "noreply@example.com",
+                "虾传",
+                WebClient.create(),
+                objectMapper);
+
+        RuntimeException ex = assertThrows(
+                RuntimeException.class,
+                () -> unconfigured.sendVerificationCode("user@example.com", "123456"));
+
+        assertEquals("邮件服务未配置，请联系管理员", ex.getMessage());
+    }
+}

--- a/backend/src/test/java/dev/ultrasend/backend/service/WebDavConnectionServiceTest.java
+++ b/backend/src/test/java/dev/ultrasend/backend/service/WebDavConnectionServiceTest.java
@@ -27,6 +27,8 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -39,6 +41,8 @@ class WebDavConnectionServiceTest {
     private WebDavConnectionRepository webDavConnectionRepository;
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private MembershipService membershipService;
     @Mock
     private Environment environment;
 
@@ -53,7 +57,39 @@ class WebDavConnectionServiceTest {
         userDataEncryption = new UserDataEncryptionService(properties, userRepository, environment);
         userDataEncryption.init();
         service = new WebDavConnectionService(
-                webDavConnectionRepository, userRepository, userDataEncryption);
+                webDavConnectionRepository, userRepository, userDataEncryption, membershipService);
+    }
+
+    private WebDavConnectionRequest sampleCreateRequest() {
+        WebDavConnectionRequest req = new WebDavConnectionRequest();
+        req.setName("NAS");
+        req.setBaseUrl("https://dav.example.com");
+        req.setUsername("alice");
+        req.setPassword("secret-pass");
+        req.setRootPath("/files");
+        return req;
+    }
+
+    @Test
+    void createRejectedForFreeUser() {
+        doThrow(new IllegalArgumentException(MembershipService.WEBDAV_MEMBER_ONLY_MESSAGE))
+                .when(membershipService).ensureCanAddWebDav(7L);
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> service.create(7L, sampleCreateRequest()));
+        assertEquals(MembershipService.WEBDAV_MEMBER_ONLY_MESSAGE, ex.getMessage());
+    }
+
+    @Test
+    void testDraftRejectedForFreeUser() {
+        doThrow(new IllegalArgumentException(MembershipService.WEBDAV_MEMBER_ONLY_MESSAGE))
+                .when(membershipService).ensureCanAddWebDav(7L);
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> service.testDraft(7L, sampleCreateRequest()));
+        assertEquals(MembershipService.WEBDAV_MEMBER_ONLY_MESSAGE, ex.getMessage());
     }
 
     @Test
@@ -69,14 +105,11 @@ class WebDavConnectionServiceTest {
             return c;
         });
 
-        WebDavConnectionRequest req = new WebDavConnectionRequest();
-        req.setName("NAS");
-        req.setBaseUrl("https://dav.example.com");
-        req.setUsername("alice");
-        req.setPassword("secret-pass");
-        req.setRootPath("/files");
+        WebDavConnectionRequest req = sampleCreateRequest();
 
         service.create(7L, req);
+
+        verify(membershipService).ensureCanAddWebDav(eq(7L));
 
         ArgumentCaptor<WebDavConnection> captor = ArgumentCaptor.forClass(WebDavConnection.class);
         verify(webDavConnectionRepository).save(captor.capture());


### PR DESCRIPTION
<!--
Thanks for contributing to ShrimpSend / 虾传.
Every commit must be signed off (DCO): use `git commit -s`. See CONTRIBUTING.md and DCO.md.
Keep one logical change per PR.
-->

## What and why

<!-- What does this change do, and what problem does it solve? Link issues, e.g. Closes #123 -->

## Area

- [ ] `backend/` (Java / Spring Boot)
- [ ] `web/` (Next.js)
- [ ] `app/` (Flutter)
- [ ] `shared/protocol*` (needs client + server alignment)
- [ ] Docs / self-hosting
- [ ] Other

## How was this tested?

<!-- Commands run and manual verification steps. e.g. ./gradlew test, npm run lint, flutter analyze -->

## Checklist

- [ ] One logical change; no unrelated refactors
- [ ] No secrets, keys, or production config committed
- [ ] Formatters/linters run for touched areas
- [ ] All commits are signed off (`git commit -s`)
- [ ] Licensed under AGPL-3.0-or-later
