### PR TITLE
Default "delete cache after save" to enabled in settings.

### DIFF
--- a/app/lib/file_save_preferences.dart
+++ b/app/lib/file_save_preferences.dart
@@ -21,7 +21,7 @@ Future<void> setSaveToGallery(bool value) async {
 
 Future<bool> getDeleteCacheAfterSave() async {
   final prefs = await SharedPreferences.getInstance();
-  return prefs.getBool(_keyDeleteCacheAfterSave) ?? false;
+  return prefs.getBool(_keyDeleteCacheAfterSave) ?? true;
 }
 
 Future<void> setDeleteCacheAfterSave(bool value) async {

--- a/app/lib/screens/settings_screen.dart
+++ b/app/lib/screens/settings_screen.dart
@@ -64,7 +64,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   S3StorageMode _s3Mode = S3StorageMode.disabled;
   bool _loading = true;
   bool _saveToGallery = false;
-  bool _deleteCacheAfterSave = false;
+  bool _deleteCacheAfterSave = true;
   bool _windowsLaunchAtStartup = false;
   bool _autoCopyReceivedText = true;
   String? _customSaveDir;


### PR DESCRIPTION
New users and unset preferences now keep cache cleanup on by default.

<!--
Thanks for contributing to ShrimpSend / 虾传.
Every commit must be signed off (DCO): use `git commit -s`. See CONTRIBUTING.md and DCO.md.
Keep one logical change per PR.
-->

## What and why

<!-- What does this change do, and what problem does it solve? Link issues, e.g. Closes #123 -->

## Area

- [ ] `backend/` (Java / Spring Boot)
- [ ] `web/` (Next.js)
- [x] `app/` (Flutter)
- [ ] `shared/protocol*` (needs client + server alignment)
- [ ] Docs / self-hosting
- [ ] Other

## How was this tested?

<!-- Commands run and manual verification steps. e.g. ./gradlew test, npm run lint, flutter analyze -->

## Checklist

- [ ] One logical change; no unrelated refactors
- [ ] No secrets, keys, or production config committed
- [ ] Formatters/linters run for touched areas
- [ ] All commits are signed off (`git commit -s`)
- [ ] Licensed under AGPL-3.0-or-later
