### PR TITLE
Cursor/windows cmake cache fix

### DIFF
--- a/app/lib/api/webdav.dart
+++ b/app/lib/api/webdav.dart
@@ -74,20 +74,6 @@ class WebDavCredentials {
   };
 }
 
-class WebDavTestResult {
-  final bool ok;
-  final String message;
-
-  const WebDavTestResult({required this.ok, required this.message});
-
-  factory WebDavTestResult.fromJson(Map<String, dynamic> j) {
-    return WebDavTestResult(
-      ok: j['ok'] as bool? ?? false,
-      message: j['message'] as String? ?? '',
-    );
-  }
-}
-
 class WebDavConnectionRequest {
   final String name;
   final String baseUrl;
@@ -207,33 +193,3 @@ Future<void> deleteWebDavConnection(int id) async {
   });
 }
 
-Future<WebDavTestResult> testWebDavConnection(int id) async {
-  return withAuthRetry(() async {
-    final r = await http.post(
-      Uri.parse('$apiBaseUrl/api/webdav/connections/$id/test'),
-      headers: apiHeaders,
-    );
-    checkAuthResponse(r, fallback: '测试 WebDAV 连接失败');
-    if (r.statusCode != 200) throw Exception('测试 WebDAV 连接失败');
-    return WebDavTestResult.fromJson(
-      jsonDecode(r.body) as Map<String, dynamic>,
-    );
-  });
-}
-
-Future<WebDavTestResult> testWebDavConnectionDraft(
-  WebDavConnectionRequest req,
-) async {
-  return withAuthRetry(() async {
-    final r = await http.post(
-      Uri.parse('$apiBaseUrl/api/webdav/connections/test'),
-      headers: apiHeaders,
-      body: jsonEncode(req.toJson()),
-    );
-    checkAuthResponse(r, fallback: '测试 WebDAV 连接失败');
-    if (r.statusCode != 200) throw Exception('测试 WebDAV 连接失败');
-    return WebDavTestResult.fromJson(
-      jsonDecode(r.body) as Map<String, dynamic>,
-    );
-  });
-}

--- a/app/lib/screens/webdav_connection_screen.dart
+++ b/app/lib/screens/webdav_connection_screen.dart
@@ -6,6 +6,7 @@ import '../api/api.dart';
 import '../l10n/generated/app_localizations.dart';
 import '../providers/webdav_provider.dart';
 import '../services/webdav_credential_store.dart';
+import '../services/webdav_session.dart';
 import '../ui/app_ui.dart';
 import '../utils/auth_route_guard.dart';
 import '../utils/toast.dart';
@@ -112,6 +113,22 @@ class _WebDavConnectionScreenState extends ConsumerState<WebDavConnectionScreen>
     );
   }
 
+  Future<WebDavCredentials> _credentialsForTest() async {
+    final req = _buildRequest();
+    var password = req.password ?? '';
+    if (_isEdit && password.isEmpty) {
+      final stored = await fetchWebDavCredentials(widget.connectionId!);
+      password = stored.password;
+    }
+    return buildWebDavTestCredentials(
+      baseUrl: req.baseUrl,
+      username: req.username ?? '',
+      password: password,
+      rootPath: req.rootPath ?? '/',
+      clientApp: req.clientApp,
+    );
+  }
+
   Future<void> _test() async {
     if (!_formKey.currentState!.validate()) return;
     if (!_isEdit && _passwordController.text.isEmpty) {
@@ -123,14 +140,10 @@ class _WebDavConnectionScreenState extends ConsumerState<WebDavConnectionScreen>
     setState(() => _testing = true);
     final l10n = AppLocalizations.of(context);
     try {
-      final result = _isEdit && _passwordController.text.isEmpty
-          ? await testWebDavConnection(widget.connectionId!)
-          : await testWebDavConnectionDraft(_buildRequest());
+      final creds = await _credentialsForTest();
+      await testWebDavConnectionLocally(creds);
       if (!mounted) return;
-      AppToast.show(
-        context,
-        message: result.ok ? l10n.webdavTestSuccess : result.message,
-      );
+      AppToast.show(context, message: l10n.webdavTestSuccess);
     } catch (e) {
       if (!mounted) return;
       AppToast.show(context, message: l10n.webdavTestFailed('$e'));

--- a/app/lib/services/webdav_session.dart
+++ b/app/lib/services/webdav_session.dart
@@ -35,6 +35,33 @@ class WebDavEntry {
   });
 }
 
+/// Builds credentials for a direct client-side connection test.
+WebDavCredentials buildWebDavTestCredentials({
+  required String baseUrl,
+  required String username,
+  required String password,
+  required String rootPath,
+  String? clientApp,
+}) {
+  final root = rootPath.trim().isEmpty ? '/' : rootPath.trim();
+  return WebDavCredentials(
+    username: username.trim(),
+    password: password,
+    baseUrl: baseUrl.trim(),
+    rootPath: root,
+    clientApp: clientApp,
+  );
+}
+
+/// Tests connectivity by pinging WebDAV directly from the client.
+///
+/// Uses the same [WebDavClient] stack as browse/upload (Digest/Basic via
+/// webdav_client), not the backend Basic-only PROPFIND probe.
+Future<void> testWebDavConnectionLocally(WebDavCredentials creds) async {
+  final client = WebDavClient(creds);
+  await client.ping();
+}
+
 /// Thin adapter over vendored [wd.Client] for Ultrasend WebDAV UI.
 class WebDavClient {
   WebDavClient(WebDavCredentials creds) : _client = _createClient(creds);

--- a/app/lib/widgets/webdav/webdav_connection_actions.dart
+++ b/app/lib/widgets/webdav/webdav_connection_actions.dart
@@ -50,12 +50,13 @@ Future<void> showWebDavConnectionMenu(
             onTap: () async {
               Navigator.pop(ctx);
               try {
-                final result = await testWebDavConnection(conn.id);
-                if (!context.mounted) return;
-                AppToast.show(
-                  context,
-                  message: result.ok ? l10n.webdavTestSuccess : result.message,
+                final creds = await resolveWebDavCredentials(
+                  conn.id,
+                  forceRefresh: true,
                 );
+                await testWebDavConnectionLocally(creds);
+                if (!context.mounted) return;
+                AppToast.show(context, message: l10n.webdavTestSuccess);
               } catch (e) {
                 if (!context.mounted) return;
                 AppToast.show(context, message: l10n.webdavTestFailed('$e'));

--- a/app/packages/webdav_client/CHANGELOG.md
+++ b/app/packages/webdav_client/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### [1.2.2] (vendored)
+- Retry with Digest auth when a preemptive Basic request gets 401 + `WWW-Authenticate: Digest` (fixes Digest-only servers such as Railway WebDAV).
+
 ### [1.2.1]
 - Dio Dependency Update
 

--- a/app/packages/webdav_client/lib/src/webdav_dio.dart
+++ b/app/packages/webdav_client/lib/src/webdav_dio.dart
@@ -146,28 +146,26 @@ class WdDio with DioMixin implements Dio {
     if (resp.statusCode == 401) {
       String? w3AHeader = resp.headers.value('www-authenticate');
       String? lowerW3AHeader = w3AHeader?.toLowerCase();
+      final wantsDigest = lowerW3AHeader?.contains('digest') == true;
+      final wantsBasic = lowerW3AHeader?.contains('basic') == true;
 
-      // before is noAuth
-      if (self.auth.type == AuthType.NoAuth) {
-        // Digest
-        if (lowerW3AHeader?.contains('digest') == true) {
-          self.auth = DigestAuth(
-              user: self.auth.user,
-              pwd: self.auth.pwd,
-              dParts: DigestParts(w3AHeader));
-          detectedAuthType = AuthType.DigestAuth;
-        }
-        // Basic
-        else if (lowerW3AHeader?.contains('basic') == true) {
-          self.auth = BasicAuth(user: self.auth.user, pwd: self.auth.pwd);
-          detectedAuthType = AuthType.BasicAuth;
-        }
-        // error
-        else {
-          throw newResponseError(resp);
-        }
+      // Digest-only servers (e.g. Railway WebDAV) reject preemptive Basic and
+      // return 401 + WWW-Authenticate: Digest. Upgrade from NoAuth or BasicAuth.
+      if (wantsDigest &&
+          (self.auth.type == AuthType.NoAuth ||
+              self.auth.type == AuthType.BasicAuth)) {
+        self.auth = DigestAuth(
+            user: self.auth.user,
+            pwd: self.auth.pwd,
+            dParts: DigestParts(w3AHeader));
+        detectedAuthType = AuthType.DigestAuth;
       }
-      // before is digest and Nonce Lifetime is out
+      // Server advertises Basic and we have not tried credentials yet.
+      else if (self.auth.type == AuthType.NoAuth && wantsBasic) {
+        self.auth = BasicAuth(user: self.auth.user, pwd: self.auth.pwd);
+        detectedAuthType = AuthType.BasicAuth;
+      }
+      // Nonce expired during an ongoing Digest session.
       else if (self.auth.type == AuthType.DigestAuth &&
           lowerW3AHeader?.contains('stale=true') == true) {
         self.auth = DigestAuth(

--- a/app/packages/webdav_client/test/digest_auth_test.dart
+++ b/app/packages/webdav_client/test/digest_auth_test.dart
@@ -1,0 +1,38 @@
+import 'package:test/test.dart';
+import 'package:webdav_client/src/auth.dart';
+
+void main() {
+  group('DigestParts', () {
+    test('parses Railway-style WWW-Authenticate header', () {
+      const header =
+          'Digest realm="Default realm", qop="auth", nonce="abc123", opaque="opaque456"';
+      final parts = DigestParts(header);
+
+      expect(parts.parts['realm'], 'Default realm');
+      expect(parts.parts['qop'], 'auth');
+      expect(parts.parts['nonce'], 'abc123');
+      expect(parts.parts['opaque'], 'opaque456');
+    });
+  });
+
+  group('DigestAuth', () {
+    test('authorize produces Digest header with qop and opaque', () {
+      const header =
+          'Digest realm="Default realm", qop="auth", nonce="abc123", opaque="opaque456"';
+      final auth = DigestAuth(
+        user: 'root',
+        pwd: 'secret',
+        dParts: DigestParts(header),
+      );
+
+      final value = auth.authorize('PROPFIND', '/');
+      expect(value, startsWith('Digest username="root"'));
+      expect(value, contains('realm="Default realm"'));
+      expect(value, contains('nonce="abc123"'));
+      expect(value, contains('uri="/"'));
+      expect(value, contains('qop=auth'));
+      expect(value, contains('opaque=opaque456'));
+      expect(value, contains('response="'));
+    });
+  });
+}

--- a/app/scripts/package_windows.ps1
+++ b/app/scripts/package_windows.ps1
@@ -116,12 +116,23 @@ function ConvertTo-FourPartVersion([string] $versionLine) {
 function Clear-WindowsCmakeStaleCache {
     $windowsBuild = Join-Path $AppDir 'build\windows'
     if (-not (Test-Path -LiteralPath $windowsBuild)) { return }
+    Write-Host "Remove Windows build dir: $windowsBuild"
+    for ($i = 0; $i -lt 3; $i++) {
+        Remove-Item -LiteralPath $windowsBuild -Recurse -Force -ErrorAction SilentlyContinue
+        if (-not (Test-Path -LiteralPath $windowsBuild)) { return }
+        Start-Sleep -Milliseconds 500
+    }
     Get-ChildItem -LiteralPath $windowsBuild -Recurse -Force -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -eq 'CMakeCache.txt' -or $_.Name -eq 'CMakeFiles' } |
         ForEach-Object {
             Write-Host "Remove stale CMake: $($_.FullName)"
             Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
         }
+    $stale = Get-ChildItem -LiteralPath $windowsBuild -Recurse -Force -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -eq 'CMakeCache.txt' }
+    if ($stale) {
+        Write-Error "Stale CMakeCache.txt could not be removed (likely locked). Close the running app/IDE and retry: $($stale.FullName)"
+    }
 }
 
 function Invoke-PackageWindowsRegion {

--- a/app/test/webdav_local_test_test.dart
+++ b/app/test/webdav_local_test_test.dart
@@ -1,0 +1,51 @@
+import 'package:app/api/webdav.dart';
+import 'package:app/services/webdav_cstcloud.dart';
+import 'package:app/services/webdav_session.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('buildWebDavTestCredentials', () {
+    test('trims fields and defaults empty root to slash', () {
+      final creds = buildWebDavTestCredentials(
+        baseUrl: ' https://dav.example.com/ ',
+        username: ' root ',
+        password: 'secret',
+        rootPath: '',
+      );
+
+      expect(creds.baseUrl, 'https://dav.example.com/');
+      expect(creds.username, 'root');
+      expect(creds.password, 'secret');
+      expect(creds.rootPath, '/');
+      expect(creds.clientApp, isNull);
+    });
+
+    test('preserves clientApp for data capsule hosts', () {
+      final creds = buildWebDavTestCredentials(
+        baseUrl: 'https://data.cstcloud.cn/dav',
+        username: 'u',
+        password: 'p',
+        rootPath: '/',
+        clientApp: 'zotero',
+      );
+
+      expect(creds.clientApp, 'zotero');
+      expect(resolveWebDavUserAgent(creds), kCstCloudWebDavUserAgent);
+    });
+
+    test('builds root URI matching browse path', () {
+      final creds = buildWebDavTestCredentials(
+        baseUrl: 'https://webdav-production-444b.up.railway.app/',
+        username: 'root',
+        password: 'p',
+        rootPath: '/',
+      );
+
+      expect(
+        buildWebDavRootUri(creds.baseUrl, creds.rootPath),
+        'https://webdav-production-444b.up.railway.app/',
+      );
+      expect(resolveWebDavUserAgent(creds), isNull);
+    });
+  });
+}


### PR DESCRIPTION
<!--
Thanks for contributing to ShrimpSend / 虾传.
Every commit must be signed off (DCO): use `git commit -s`. See CONTRIBUTING.md and DCO.md.
Keep one logical change per PR.
-->

## What and why

<!-- What does this change do, and what problem does it solve? Link issues, e.g. Closes #123 -->

## Area

- [ ] `backend/` (Java / Spring Boot)
- [ ] `web/` (Next.js)
- [x] `app/` (Flutter)
- [ ] `shared/protocol*` (needs client + server alignment)
- [ ] Docs / self-hosting
- [ ] Other

## How was this tested?

<!-- Commands run and manual verification steps. e.g. ./gradlew test, npm run lint, flutter analyze -->

## Checklist

- [ ] One logical change; no unrelated refactors
- [ ] No secrets, keys, or production config committed
- [ ] Formatters/linters run for touched areas
- [ ] All commits are signed off (`git commit -s`)
- [ ] Licensed under AGPL-3.0-or-later
