### PR TITLE
修复(windows): 自启动时跳过原生首帧强制显示窗口

### DIFF
--- a/app/lib/services/transfer_error_message.dart
+++ b/app/lib/services/transfer_error_message.dart
@@ -5,10 +5,11 @@ String _dioExceptionTypeLabel(DioExceptionType type) {
     DioExceptionType.connectionTimeout => '连接超时',
     DioExceptionType.sendTimeout => '发送超时',
     DioExceptionType.receiveTimeout => '接收超时',
-    DioExceptionType.cancel => '已取消',
-    DioExceptionType.connectionError => '连接错误',
     DioExceptionType.badCertificate => '证书错误',
     DioExceptionType.badResponse => '响应错误',
+    DioExceptionType.cancel => '已取消',
+    DioExceptionType.connectionError => '连接错误',
+    DioExceptionType.transformTimeout => '转换超时',
     DioExceptionType.unknown => '网络错误',
   };
 }

--- a/app/windows/runner/flutter_window.cpp
+++ b/app/windows/runner/flutter_window.cpp
@@ -3,6 +3,7 @@
 #include <flutter/encodable_value.h>
 #include <flutter/method_channel.h>
 #include <flutter/standard_method_codec.h>
+#include <algorithm>
 #include <optional>
 
 #include "flutter/generated_plugin_registrant.h"
@@ -50,9 +51,21 @@ bool FlutterWindow::OnCreate() {
   RegisterPlugins(flutter_controller_->engine());
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
 
-  flutter_controller_->engine()->SetNextFrameCallback([&]() {
-    this->Show();
-  });
+  // When launched at startup (--startup arg, registered by
+  // windows_launch_at_startup_service.dart), the Dart layer keeps the window
+  // hidden via window_manager and parks it in the tray. An unconditional
+  // Show() on the first frame would override that hide and pop the window
+  // onto the desktop, so skip it here and let window_manager own visibility.
+  const auto& entrypoint_args = project_.dart_entrypoint_arguments();
+  const bool launched_at_startup =
+      std::find(entrypoint_args.begin(), entrypoint_args.end(),
+                "--startup") != entrypoint_args.end();
+
+  if (!launched_at_startup) {
+    flutter_controller_->engine()->SetNextFrameCallback([&]() {
+      this->Show();
+    });
+  }
 
   // Flutter can complete the first frame before the "show window" callback is
   // registered. The following call ensures a frame is pending to ensure the


### PR DESCRIPTION
## 问题

Windows 开机自启动时，窗口未按预期隐藏，而是直接弹出桌面。

## 根因分析

启动链路：
1. 自启动配置写入注册表，命令为 `虾传.exe --startup`（见 `windows_launch_at_startup_service.dart`）
2. Dart 层识别 `--startup`，调用 `initDesktopWindowBeforeRunApp(startHidden: true)` 执行 `window_manager.hide()`
3. **但原生 Flutter Runner（`flutter_window.cpp`）在 `OnCreate` 中无条件注册了首帧回调：**
```cpp
flutter_controller_->engine()->SetNextFrameCallback([&]() {
  this->Show();
});
```
4. Flutter 首帧完成 → 原生层无条件 `Show()` → 覆盖 Dart 层的 `hide()` → 窗口重新出现在桌面

## 修复方案

`flutter_window.cpp`：通过 `project_.dart_entrypoint_arguments()` 检测 `--startup` 参数，检测到时跳过注册首帧 `Show()` 回调，将窗口可见性完全交给 `window_manager` 控制。

`transfer_error_message.dart`：补全 `DioExceptionType.transformTimeout` 分支（新版 dio 新增的枚举值导致原有 switch 编译失败）。

## 测试验证

| 启动方式 | MainWindowTitle | MainWindowHandle | 结果 |
|---------|----------------|------------------|------|
| `虾传.exe --startup` | `''`（空） | `0` | 窗口隐藏 ✅ |
| `虾传.exe`（无参数） | `'虾传'` | `199200` | 窗口正常显示 ✅ |

C++ 语法检查通过（MSVC 19.50 `cl.exe /Zs` 零错误零警告）。

## 影响范围

- 仅影响 Windows 平台
- 自启动场景：窗口保持隐藏，仅驻留托盘
- 手动启动场景：保持原有首帧显示行为，无变化